### PR TITLE
Update RichText dependencies

### DIFF
--- a/src/block/rich-text/edit.js
+++ b/src/block/rich-text/edit.js
@@ -2,7 +2,7 @@
  * WP dependencies
  */
 const {
-	editor: {
+	blockEditor: {
 		RichText,
 	},
 	i18n: {

--- a/src/block/rich-text/save.js
+++ b/src/block/rich-text/save.js
@@ -2,7 +2,7 @@
  * WP dependencies
  */
 const {
-	editor: {
+	blockEditor: {
 		RichText,
 	},
 } = wp;


### PR DESCRIPTION
Change RichText dependency from editor (5.2.4) to blockEditor (5.3.2+)

### Description
Change RichText dependency from editor (5.2.4) to blockEditor (5.3.2+). This fix removes deprecation warnings present in the browser console.

### Screenshot
**Before**
<img width="1499" alt="Screen Shot 2020-03-14 at 2 30 16 PM" src="https://user-images.githubusercontent.com/25035900/76688131-7c51f300-6600-11ea-829f-ff8d0bbc9395.png">

**After**
<img width="1430" alt="Screen Shot 2020-03-14 at 2 29 29 PM" src="https://user-images.githubusercontent.com/25035900/76688130-7bb95c80-6600-11ea-9d34-93f2d87e309b.png">

### Steps to verify the solution
Check out this branch and verify that issues are resolved and the RichText block works as expected.

