### PR TITLE
Quick fix on conditionals

### DIFF
--- a/wds-block-starter.php
+++ b/wds-block-starter.php
@@ -51,7 +51,7 @@ function register_block() {
 	);
 
 	// Register editor style.
-	if ( file_exists( $editor_style ) ) {
+	if ( file_exists( plugin_dir_path( __FILE__ ) . $editor_style ) ) {
 		wp_register_style(
 			'wdsbs-editor-style',
 			plugins_url( $editor_style, __FILE__ ),
@@ -61,7 +61,7 @@ function register_block() {
 	}
 
 	// Register frontend style.
-	if ( file_exists( $frontend_style ) ) {
+	if ( file_exists( plugin_dir_path( __FILE__ ) . $frontend_style ) ) {
 		wp_register_style(
 			'wdsbs-style',
 			plugins_url( $frontend_style, __FILE__ ),


### PR DESCRIPTION
While troubleshooting stylesheets not being enqueued I noticed that `file_exists()` was checking for only part of the path. This update checks for the whole path which fixes the conditional to be true.

There is not an open issue associated with this update.

**Frontend Style Example**
<img width="439" alt="Screen Shot 2020-03-17 at 2 58 48 PM" src="https://user-images.githubusercontent.com/25035900/76892125-8a05b380-6860-11ea-9902-93d44d96bfe0.png">

**Editor Style Example**
<img width="779" alt="Screen Shot 2020-03-17 at 2 58 41 PM" src="https://user-images.githubusercontent.com/25035900/76892123-896d1d00-6860-11ea-8552-335984877b31.png">

# How to Test
- Check that styles are being enqueued
