### PR TITLE
Use __NAMESPACE__ in add_action('init')

### DIFF
--- a/wds-block-starter.php
+++ b/wds-block-starter.php
@@ -89,4 +89,4 @@ function register_block() {
 		);
 	}
 }
-add_action( 'init', 'WebDevStudios\BlockStarter\register_block' );
+add_action( 'init', __NAMESPACE__ . '\register_block' );


### PR DESCRIPTION
Closes #25 

### Description

This PR will make use of `__NAMESPACE__` in `add_action('init')` rather than hardcoding the namespace.