### PR TITLE
Replace const dependency with imports

### DIFF
--- a/src/block/rich-text/edit.js
+++ b/src/block/rich-text/edit.js
@@ -1,14 +1,8 @@
 /**
  * EDIT: Rich Rext Block
  */
-const {
-	blockEditor: {
-		RichText,
-	},
-	i18n: {
-		__,
-	},
-} = wp;
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 const Edit = ( props ) => {
 	const {


### PR DESCRIPTION
Remove const dependencies and re-add as imports that point to local packages.

Closes [#28](https://github.com/WebDevStudios/wds-block-starter/issues/28)

### Description
Replace `const` dependencies with `import` dependencies that point to local NPM packages present in WP Scripts for the Rich Text Demo block.

Also, I noticed that package bundle size did increase very slightly when using importing.

Note: Engineers can still determine how they include dependencies using either destructuring or importing as long as the file is present in the NPM package. 

### Steps to verify the solution
1. Checkout this branch
2. Verify that the block works after building files
3. Check for any abnormal console entries. Your console should look like the following:
<img width="501" alt="Screen Shot 2020-03-25 at 3 03 46 PM" src="https://user-images.githubusercontent.com/25035900/77575897-92866b80-6eaa-11ea-8307-f528f9ebe5de.png">

### Other
- [ NA ] Is this issue accessible? (Section 508/WCAG 2.1AA)
- [ NA ] Does this pass CrossBrowserTesting.com? (Edge, Safari, Chrome, Firefox)
- [ NA ] Will this pull request require [updating the wiki?](https://github.com/WebDevStudios/wds-block-starter/wiki)
