### PR TITLE
Update the style path to use @wordpress/scripts default

### DIFF
--- a/wds-block-starter.php
+++ b/wds-block-starter.php
@@ -30,8 +30,8 @@ function register_block() {
 
 	// Define our assets.
 	$editor_script   = 'build/index.js';
-	$editor_style    = 'build/editor.css';
-	$frontend_style  = 'build/style.css';
+	$editor_style    = 'build/index.css';
+	$frontend_style  = 'build/style-index.css';
 	$frontend_script = 'build/frontend.js';
 
 	// Verify we have an editor script.


### PR DESCRIPTION
Closes #37 

### Description
Update the style paths to use `@wordpress/scripts` default.

### Screenshot
**Editor**
![Screen Shot 2020-08-21 at 8 26 15 PM](https://user-images.githubusercontent.com/5747475/90890451-a0560380-e3ec-11ea-91f1-c3ab9f5bba4e.png)

**Frontend**
![Screen Shot 2020-08-21 at 8 27 12 PM](https://user-images.githubusercontent.com/5747475/90890537-c380b300-e3ec-11ea-8204-98570c71074c.png)

### Steps to verify the solution
1. Run `npm run build`.
2. You should be able to see the styles being applied to the block.
