### PR TITLE
🐛 FIX: create-block command in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _We highly recommend [NVM](https://github.com/nvm-sh/nvm) so you can easily swit
 Easily scaffold a block via CLI:
 
 ```bash
-npx @webdevstudios/block WebDevStudios/TodoList
+npx @webdevstudios/create-block WebDevStudios/TodoList
 cd todo-list
 npm run start
 ```


### PR DESCRIPTION
### Description

This PR corrects the create block command documentation in the ReadMe.md file.

### Screenshot

![screenshot](https://i.imgur.com/zIS5yrt.jpg)

### Other

- [ ] Is this issue accessible? (Section 508/WCAG 2.1AA)
- [ ] Does this pass CrossBrowserTesting.com? (Edge, Safari, Chrome, Firefox)
- [ ] Will this pull request require [updating the wiki?](https://github.com/WebDevStudios/wds-block-starter/wiki)
