### PR TITLE
Feature/40 wp scripts 14 1 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Your contributions and [support tickets](https://github.com/WebDevStudios/wds-bl
 
 ## Changelog
 
+### 1.2.0
+-   Upgrade `@wordpress/scripts` to `14.1.0`
+
 ### 1.1.1
 
 -   Fix stylesheet enqueue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wds-block-starter",
-	"version": "1.0.0",
+	"version": "1.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -14,23 +14,10 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-			"integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
+			"integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.10.5",
@@ -90,110 +77,499 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-			"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
+			"integrity": "sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz",
+			"integrity": "sha512-CZOv9tGphhDRlVjVkAgm8Nhklm9RzSmWpX2my+t7Ua/KT616pEzXsQCjinzvkRvHWJ9itO4f296efroX23XCMA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-react-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-			"integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-react-jsx-experimental": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-			"integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/types": "^7.10.5"
+				"@babel/helper-explode-assignable-expression": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-			"integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+			"integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.10.4",
-				"browserslist": "^4.12.0",
-				"invariant": "^2.2.4",
-				"levenary": "^1.1.1",
-				"semver": "^5.5.0"
+				"@babel/compat-data": "^7.13.12",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
+				"browserslist": {
+					"version": "4.16.3",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+					"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001181",
+						"colorette": "^1.2.1",
+						"electron-to-chromium": "^1.3.649",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.70"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001207",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+					"integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.709",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
+					"integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
+					"dev": true
+				},
+				"escalade": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.71",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+					"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+					"dev": true
+				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+			"version": "7.13.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+			"integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-member-expression-to-functions": "^7.10.5",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4"
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-member-expression-to-functions": "^7.13.0",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/helper-replace-supers": "^7.13.0",
+				"@babel/helper-split-export-declaration": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-			"integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
+			"integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4",
-				"regexpu-core": "^4.7.0"
+				"@babel/helper-annotate-as-pure": "^7.12.13",
+				"regexpu-core": "^4.7.1"
 			}
 		},
-		"@babel/helper-define-map": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
-			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+		"@babel/helper-define-polyfill-provider": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.5.tgz",
+			"integrity": "sha512-nXuzCSwlJ/WKr8qxzW816gwyT6VZgiJG17zR40fou70yfAcqjoNyTLl/DQ+FExw5Hx5KNqshmN8Ldl/r2N7cTg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/types": "^7.10.5",
-				"lodash": "^4.17.19"
+				"@babel/helper-compilation-targets": "^7.13.0",
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/traverse": "^7.13.0",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-			"integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz",
+			"integrity": "sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -217,12 +593,148 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
+			"integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -268,31 +780,39 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
 			"dev": true
 		},
-		"@babel/helper-regex": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
-			"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.19"
-			}
-		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-			"integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz",
+			"integrity": "sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-wrap-function": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/helper-annotate-as-pure": "^7.12.13",
+				"@babel/helper-wrap-function": "^7.13.0",
+				"@babel/types": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -318,21 +838,27 @@
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
-			"integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+			"integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-					"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -354,16 +880,157 @@
 			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+			"dev": true
+		},
 		"@babel/helper-wrap-function": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-			"integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz",
+			"integrity": "sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helpers": {
@@ -407,137 +1074,150 @@
 			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
 			"dev": true
 		},
-		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-			"integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+			"integrity": "sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-remap-async-to-generator": "^7.10.4",
-				"@babel/plugin-syntax-async-generators": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.13.12"
+			}
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+			"integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-remap-async-to-generator": "^7.13.0",
+				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
+			"integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-create-class-features-plugin": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-			"integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
+			"integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-export-namespace-from": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
-			"integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz",
+			"integrity": "sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.12.13",
 				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-			"integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
+			"integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-logical-assignment-operators": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
-			"integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+			"integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.13.0",
 				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-			"integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+			"integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-			"integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz",
+			"integrity": "sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.12.13",
 				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-			"integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+			"integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-				"@babel/plugin-transform-parameters": "^7.10.4"
+				"@babel/compat-data": "^7.13.8",
+				"@babel/helper-compilation-targets": "^7.13.8",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.13.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-			"integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
+			"integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-			"integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
+			"integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-private-methods": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-			"integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz",
+			"integrity": "sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-create-class-features-plugin": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-			"integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.13.tgz",
+			"integrity": "sha512-XyJmZidNfofEkqFV5VC/bLabGmO5QzenPO/YOfGuEbgU+2sSwMmio3YLb4WtBgcmmdwZHyVyv8on77IUjQ5Gvg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -559,12 +1239,12 @@
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
@@ -604,12 +1284,12 @@
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-			"integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
+			"integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-syntax-logical-assignment-operators": {
@@ -667,317 +1347,1565 @@
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-			"integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
+			"integrity": "sha512-A81F9pDwyS7yM//KwbCSDqy3Uj4NMIurtplxphWxoYtNPov7cJsDkAFNNyVlIZ3jwGycVsurZ+LtOA8gZ376iQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
+			"integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-			"integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz",
+			"integrity": "sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-			"integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz",
+			"integrity": "sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-remap-async-to-generator": "^7.10.4"
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-remap-async-to-generator": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-			"integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.13.tgz",
+			"integrity": "sha512-zNyFqbc3kI/fVpqwfqkg6RvBgFpC4J18aKKMmv7KdQ/1GgREapSJAykLMVNwfRGO3BtHj3YQZl8kxCXPcVMVeg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.11.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-			"integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
+			"integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-			"integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz",
+			"integrity": "sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-define-map": "^7.10.4",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/helper-annotate-as-pure": "^7.12.13",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-replace-supers": "^7.13.0",
+				"@babel/helper-split-export-declaration": "^7.12.13",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"globals": {
 					"version": "11.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-			"integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz",
+			"integrity": "sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-			"integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
+			"integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-			"integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.13.tgz",
+			"integrity": "sha512-foDrozE65ZFdUC2OfgeOCrEPTxdB3yjqxpXh8CH+ipd9CHd4s/iq81kcUpyH8ACGNEPdFqbtzfgzbT/ZGlbDeQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-			"integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.13.tgz",
+			"integrity": "sha512-NfADJiiHdhLBW3pulJlJI2NB0t4cci4WTZ8FtdIuNc2+8pslXdPtRRAEWqUY+m9kNOk2eRYbTAOipAxlrOcwwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-			"integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.13.tgz",
+			"integrity": "sha512-fbUelkM1apvqez/yYx1/oICVnGo2KM5s63mhGylrmXUxK/IAXSIf87QIxVfZldWf4QsOafY6vV3bX8aMHSvNrA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-			"integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz",
+			"integrity": "sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-			"integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.13.tgz",
+			"integrity": "sha512-6K7gZycG0cmIwwF7uMK/ZqeCikCGVBdyP2J5SKNCXO5EOHcqi+z7Jwf8AmyDNcBgxET8DrEtCt/mPKPyAzXyqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-			"integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.13.tgz",
+			"integrity": "sha512-FW+WPjSR7hiUxMcKqyNjP05tQ2kmBCdpEpZHY1ARm96tGQCCBvXKnpjILtDplUnJ/eHZ0lALLM+d2lMFSpYJrQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
-			"integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.13.tgz",
+			"integrity": "sha512-kxLkOsg8yir4YeEPHLuO2tXP9R/gTjpuTOjshqSpELUN3ZAg2jfDnKUvzzJxObun38sw3wm4Uu69sX/zA7iRvg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
-			"integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz",
+			"integrity": "sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.5",
-				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
-			"integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
+			"integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-simple-access": "^7.12.13",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
-			"integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+			"integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.10.4",
-				"@babel/helper-module-transforms": "^7.10.5",
-				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-hoist-variables": "^7.13.0",
+				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-validator-identifier": "^7.12.11",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
-			"integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz",
+			"integrity": "sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
-			"integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.13.tgz",
+			"integrity": "sha512-Xsm8P2hr5hAxyYblrfACXpQKdQbx4m2df9/ZZSQ8MAhsadw06+jW7s9zsSw6he+mJZXRlVMyEnVktJo4zjk1WA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
-			"integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.13.tgz",
+			"integrity": "sha512-/KY2hbLxrG5GTQ9zzZSc3xWiOy379pIETEhbtzwZcw9rvuaVV4Fqy7BYGYOWZnaoXIQYbbJ0ziXLa/sKcGCYEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-			"integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.13.tgz",
+			"integrity": "sha512-JzYIcj3XtYspZDV8j9ulnoMPZZnF/Cj0LUxPOjR89BdBVx+zYJI9MdMIlUZjbXDX+6YVeS6I3e8op+qQ3BYBoQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13",
+				"@babel/helper-replace-supers": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-			"integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz",
+			"integrity": "sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
-			"integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.13.tgz",
+			"integrity": "sha512-nqVigwVan+lR+g8Fj8Exl0UQX2kymtjcWfMOYM1vTYEKujeyv2SkMgazf2qNcK7l4SDiKyTA/nHCPqL4e2zo1A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-react-constant-elements": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.10.4.tgz",
-			"integrity": "sha512-cYmQBW1pXrqBte1raMkAulXmi7rjg3VI6ZLg9QIic8Hq7BtYXaWuZSxsr2siOMI6SWwpxjWfnwhTUrd7JlAV7g==",
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.13.tgz",
+			"integrity": "sha512-SNJU53VM/SjQL0bZhyU+f4kJQz7bQQajnrZRSaU21hruG/NWY41AEM9AWXeXX90pYr/C2yAmTgI6yW3LlLrAUQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
-			"integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.13.tgz",
+			"integrity": "sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-			"integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
+			"integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.10.4",
-				"@babel/helper-builder-react-jsx-experimental": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.10.4"
+				"@babel/helper-annotate-as-pure": "^7.12.13",
+				"@babel/helper-module-imports": "^7.13.12",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-jsx": "^7.12.13",
+				"@babel/types": "^7.13.12"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-react-jsx-development": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz",
-			"integrity": "sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==",
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.17.tgz",
+			"integrity": "sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx-experimental": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
-			"integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz",
-			"integrity": "sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.10.4"
+				"@babel/plugin-transform-react-jsx": "^7.12.17"
 			}
 		},
 		"@babel/plugin-transform-react-pure-annotations": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
-			"integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",
+			"integrity": "sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
@@ -985,209 +2913,253 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-			"integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz",
+			"integrity": "sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
-			"integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.13.tgz",
+			"integrity": "sha512-xhUPzDXxZN1QfiOy/I5tyye+TRz6lA7z6xaT4CLOjPRMVg1ldRf0LHw0TDBpYL4vG78556WuHdyO9oi5UmzZBg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-			"integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.10.tgz",
+			"integrity": "sha512-Y5k8ipgfvz5d/76tx7JYbKQTcgFSU6VgJ3kKQv4zGTKr+a9T/KBvfRvGtSFgKDQGt/DBykQixV0vNWKIdzWErA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"resolve": "^1.8.1",
-				"semver": "^5.5.1"
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"babel-plugin-polyfill-corejs2": "^0.1.4",
+				"babel-plugin-polyfill-corejs3": "^0.1.3",
+				"babel-plugin-polyfill-regenerator": "^0.1.2",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-			"integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-spread": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
-			"integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
-			}
-		},
-		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-			"integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-template-literals": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
-			"integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-			"integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-unicode-escapes": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
-			"integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-			"integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
-			}
-		},
-		"@babel/preset-env": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-			"integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
-			"dev": true,
-			"requires": {
-				"@babel/compat-data": "^7.11.0",
-				"@babel/helper-compilation-targets": "^7.10.4",
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-				"@babel/plugin-proposal-class-properties": "^7.10.4",
-				"@babel/plugin-proposal-dynamic-import": "^7.10.4",
-				"@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-				"@babel/plugin-proposal-json-strings": "^7.10.4",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-				"@babel/plugin-proposal-numeric-separator": "^7.10.4",
-				"@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-				"@babel/plugin-proposal-optional-chaining": "^7.11.0",
-				"@babel/plugin-proposal-private-methods": "^7.10.4",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-				"@babel/plugin-syntax-async-generators": "^7.8.0",
-				"@babel/plugin-syntax-class-properties": "^7.10.4",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
-				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-json-strings": "^7.8.0",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-				"@babel/plugin-syntax-top-level-await": "^7.10.4",
-				"@babel/plugin-transform-arrow-functions": "^7.10.4",
-				"@babel/plugin-transform-async-to-generator": "^7.10.4",
-				"@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-				"@babel/plugin-transform-block-scoping": "^7.10.4",
-				"@babel/plugin-transform-classes": "^7.10.4",
-				"@babel/plugin-transform-computed-properties": "^7.10.4",
-				"@babel/plugin-transform-destructuring": "^7.10.4",
-				"@babel/plugin-transform-dotall-regex": "^7.10.4",
-				"@babel/plugin-transform-duplicate-keys": "^7.10.4",
-				"@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-				"@babel/plugin-transform-for-of": "^7.10.4",
-				"@babel/plugin-transform-function-name": "^7.10.4",
-				"@babel/plugin-transform-literals": "^7.10.4",
-				"@babel/plugin-transform-member-expression-literals": "^7.10.4",
-				"@babel/plugin-transform-modules-amd": "^7.10.4",
-				"@babel/plugin-transform-modules-commonjs": "^7.10.4",
-				"@babel/plugin-transform-modules-systemjs": "^7.10.4",
-				"@babel/plugin-transform-modules-umd": "^7.10.4",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-				"@babel/plugin-transform-new-target": "^7.10.4",
-				"@babel/plugin-transform-object-super": "^7.10.4",
-				"@babel/plugin-transform-parameters": "^7.10.4",
-				"@babel/plugin-transform-property-literals": "^7.10.4",
-				"@babel/plugin-transform-regenerator": "^7.10.4",
-				"@babel/plugin-transform-reserved-words": "^7.10.4",
-				"@babel/plugin-transform-shorthand-properties": "^7.10.4",
-				"@babel/plugin-transform-spread": "^7.11.0",
-				"@babel/plugin-transform-sticky-regex": "^7.10.4",
-				"@babel/plugin-transform-template-literals": "^7.10.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.10.4",
-				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
-				"@babel/plugin-transform-unicode-regex": "^7.10.4",
-				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.11.0",
-				"browserslist": "^4.12.0",
-				"core-js-compat": "^3.6.2",
-				"invariant": "^2.2.2",
-				"levenary": "^1.1.1",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.11.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-					"integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
+			"integrity": "sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz",
+			"integrity": "sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.13.tgz",
+			"integrity": "sha512-Jc3JSaaWT8+fr7GRvQP02fKDsYk4K/lYwWq38r/UGfaxo89ajud321NH28KRQ7xy1Ybc0VUE5Pz8psjNNDUglg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz",
+			"integrity": "sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.13.tgz",
+			"integrity": "sha512-eKv/LmUJpMnu4npgfvs3LiHhJua5fo/CysENxa45YCQXZwKnGCQKAg87bvoqSW1fFT+HA32l03Qxsm8ouTY3ZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.13.0.tgz",
+			"integrity": "sha512-elQEwluzaU8R8dbVuW2Q2Y8Nznf7hnjM7+DSCd14Lo5fF63C9qNLbwZYbmZrtV9/ySpSUpkRpQXvJb6xyu4hCQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.13.0",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/plugin-syntax-typescript": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz",
+			"integrity": "sha512-0bHEkdwJ/sN/ikBHfSmOXPypN/beiGqjo+o4/5K+vxEFNPRPdImhviPakMKG4x96l85emoa0Z6cDflsdBusZbw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.13.tgz",
+			"integrity": "sha512-mDRzSNY7/zopwisPZ5kM9XKCfhchqIYwAKRERtEnhYscZB79VRekuRSoYbN0+KVe3y8+q1h6A4svXtP7N+UoCA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.12.13"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
+			"integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.12",
+				"@babel/helper-compilation-targets": "^7.13.10",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-validator-option": "^7.12.17",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
+				"@babel/plugin-proposal-async-generator-functions": "^7.13.8",
+				"@babel/plugin-proposal-class-properties": "^7.13.0",
+				"@babel/plugin-proposal-dynamic-import": "^7.13.8",
+				"@babel/plugin-proposal-export-namespace-from": "^7.12.13",
+				"@babel/plugin-proposal-json-strings": "^7.13.8",
+				"@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.13",
+				"@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
+				"@babel/plugin-proposal-optional-chaining": "^7.13.12",
+				"@babel/plugin-proposal-private-methods": "^7.13.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.12.13",
+				"@babel/plugin-transform-arrow-functions": "^7.13.0",
+				"@babel/plugin-transform-async-to-generator": "^7.13.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.12.13",
+				"@babel/plugin-transform-block-scoping": "^7.12.13",
+				"@babel/plugin-transform-classes": "^7.13.0",
+				"@babel/plugin-transform-computed-properties": "^7.13.0",
+				"@babel/plugin-transform-destructuring": "^7.13.0",
+				"@babel/plugin-transform-dotall-regex": "^7.12.13",
+				"@babel/plugin-transform-duplicate-keys": "^7.12.13",
+				"@babel/plugin-transform-exponentiation-operator": "^7.12.13",
+				"@babel/plugin-transform-for-of": "^7.13.0",
+				"@babel/plugin-transform-function-name": "^7.12.13",
+				"@babel/plugin-transform-literals": "^7.12.13",
+				"@babel/plugin-transform-member-expression-literals": "^7.12.13",
+				"@babel/plugin-transform-modules-amd": "^7.13.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.13.8",
+				"@babel/plugin-transform-modules-systemjs": "^7.13.8",
+				"@babel/plugin-transform-modules-umd": "^7.13.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
+				"@babel/plugin-transform-new-target": "^7.12.13",
+				"@babel/plugin-transform-object-super": "^7.12.13",
+				"@babel/plugin-transform-parameters": "^7.13.0",
+				"@babel/plugin-transform-property-literals": "^7.12.13",
+				"@babel/plugin-transform-regenerator": "^7.12.13",
+				"@babel/plugin-transform-reserved-words": "^7.12.13",
+				"@babel/plugin-transform-shorthand-properties": "^7.12.13",
+				"@babel/plugin-transform-spread": "^7.13.0",
+				"@babel/plugin-transform-sticky-regex": "^7.12.13",
+				"@babel/plugin-transform-template-literals": "^7.13.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.13",
+				"@babel/plugin-transform-unicode-escapes": "^7.12.13",
+				"@babel/plugin-transform-unicode-regex": "^7.12.13",
+				"@babel/preset-modules": "^0.1.4",
+				"@babel/types": "^7.13.12",
+				"babel-plugin-polyfill-corejs2": "^0.1.4",
+				"babel-plugin-polyfill-corejs3": "^0.1.3",
+				"babel-plugin-polyfill-regenerator": "^0.1.2",
+				"core-js-compat": "^3.9.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/preset-modules": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-			"integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+			"integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -1198,18 +3170,28 @@
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
-			"integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
+			"version": "7.13.13",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.13.13.tgz",
+			"integrity": "sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-transform-react-display-name": "^7.10.4",
-				"@babel/plugin-transform-react-jsx": "^7.10.4",
-				"@babel/plugin-transform-react-jsx-development": "^7.10.4",
-				"@babel/plugin-transform-react-jsx-self": "^7.10.4",
-				"@babel/plugin-transform-react-jsx-source": "^7.10.4",
-				"@babel/plugin-transform-react-pure-annotations": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-validator-option": "^7.12.17",
+				"@babel/plugin-transform-react-display-name": "^7.12.13",
+				"@babel/plugin-transform-react-jsx": "^7.13.12",
+				"@babel/plugin-transform-react-jsx-development": "^7.12.17",
+				"@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+			}
+		},
+		"@babel/preset-typescript": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.13.0.tgz",
+			"integrity": "sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/helper-validator-option": "^7.12.17",
+				"@babel/plugin-transform-typescript": "^7.13.0"
 			}
 		},
 		"@babel/runtime": {
@@ -1292,6 +3274,60 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@eslint/eslintrc": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+			"integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+					"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"espree": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+					"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.4.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^1.3.0"
+					}
+				}
 			}
 		},
 		"@hapi/address": {
@@ -1410,161 +3446,69 @@
 			}
 		},
 		"@istanbuljs/schema": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
-			"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+			"integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"jest-message-util": "^25.5.0",
-				"jest-util": "^25.5.0",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^26.6.2",
+				"jest-util": "^26.6.2",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@jest/core": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
-			"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+			"integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/reporters": "^25.5.1",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
+				"@jest/console": "^26.6.2",
+				"@jest/reporters": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^25.5.0",
-				"jest-config": "^25.5.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-message-util": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-resolve-dependencies": "^25.5.4",
-				"jest-runner": "^25.5.4",
-				"jest-runtime": "^25.5.4",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
-				"jest-watcher": "^25.5.0",
+				"jest-changed-files": "^26.6.2",
+				"jest-config": "^26.6.3",
+				"jest-haste-map": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.2",
+				"jest-resolve-dependencies": "^26.6.3",
+				"jest-runner": "^26.6.3",
+				"jest-runtime": "^26.6.3",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
+				"jest-watcher": "^26.6.2",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
-				"realpath-native": "^2.0.0",
 				"rimraf": "^3.0.0",
 				"slash": "^3.0.0",
 				"strip-ansi": "^6.0.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+					"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.11.0"
+						"type-fest": "^0.21.3"
 					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
 				},
 				"rimraf": {
 					"version": "3.0.2",
@@ -1575,147 +3519,88 @@
 						"glob": "^7.1.3"
 					}
 				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
 				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
 		},
 		"@jest/environment": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
-			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+			"integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0"
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
-			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+			"integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"lolex": "^5.0.0"
+				"@jest/types": "^26.6.2",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@types/node": "*",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
 			}
 		},
 		"@jest/globals": {
-			"version": "25.5.2",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
-			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+			"integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"expect": "^25.5.0"
+				"@jest/environment": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"expect": "^26.6.2"
 			}
 		},
 		"@jest/reporters": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
-			"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+			"integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
+				"@jest/console": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
 				"graceful-fs": "^4.2.4",
 				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-instrument": "^4.0.3",
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^25.5.1",
-				"jest-resolve": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
-				"node-notifier": "^6.0.0",
+				"jest-haste-map": "^26.6.2",
+				"jest-resolve": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
+				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
-				"string-length": "^3.1.0",
+				"string-length": "^4.0.1",
 				"terminal-link": "^2.0.0",
-				"v8-to-istanbul": "^4.1.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"v8-to-istanbul": "^7.0.0"
 			}
 		},
 		"@jest/source-map": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
-			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+			"integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
@@ -1724,168 +3609,64 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
-			"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+			"integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/types": "^25.5.0",
+				"@jest/console": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
-			"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+			"integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.5.0",
+				"@jest/test-result": "^26.6.2",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-runner": "^25.5.4",
-				"jest-runtime": "^25.5.4"
+				"jest-haste-map": "^26.6.2",
+				"jest-runner": "^26.6.3",
+				"jest-runtime": "^26.6.3"
 			}
 		},
 		"@jest/transform": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
-			"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+			"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^25.5.0",
+				"@jest/types": "^26.6.2",
 				"babel-plugin-istanbul": "^6.0.0",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-regex-util": "^25.2.6",
-				"jest-util": "^25.5.0",
+				"jest-haste-map": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-util": "^26.6.2",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
-				"realpath-native": "^2.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.1",
 				"write-file-atomic": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@jest/types": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
 				"@types/yargs": "^15.0.0",
-				"chalk": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"chalk": "^4.0.0"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1899,19 +3680,19 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+			"integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.3",
+				"@nodelib/fs.stat": "2.0.4",
 				"run-parallel": "^1.1.9"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 					"dev": true
 				}
 			}
@@ -1923,22 +3704,23 @@
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+			"integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.3",
+				"@nodelib/fs.scandir": "2.1.4",
 				"fastq": "^1.6.0"
 			}
 		},
 		"@npmcli/move-file": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
-			"integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+			"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^1.0.4"
+				"mkdirp": "^1.0.4",
+				"rimraf": "^3.0.2"
 			},
 			"dependencies": {
 				"mkdirp": {
@@ -1946,16 +3728,40 @@
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
+		"@polka/url": {
+			"version": "1.0.0-next.12",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.12.tgz",
+			"integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==",
+			"dev": true
+		},
 		"@sinonjs/commons": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+			"integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
 			}
 		},
 		"@stylelint/postcss-css-in-js": {
@@ -1968,19 +3774,19 @@
 			}
 		},
 		"@stylelint/postcss-markdown": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.1.tgz",
-			"integrity": "sha512-iDxMBWk9nB2BPi1VFQ+Dc5+XpvODBHw2n3tYpaBZuEAFQlbtF9If0Qh5LTTwSi/XwdbJ2jt+0dis3i8omyggpw==",
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
+			"integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
 			"dev": true,
 			"requires": {
-				"remark": "^12.0.0",
-				"unist-util-find-all-after": "^3.0.1"
+				"remark": "^13.0.0",
+				"unist-util-find-all-after": "^3.0.2"
 			},
 			"dependencies": {
 				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
 					"dev": true
 				},
 				"is-plain-obj": {
@@ -1989,112 +3795,39 @@
 					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 					"dev": true
 				},
-				"markdown-table": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-					"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-					"dev": true,
-					"requires": {
-						"repeat-string": "^1.0.0"
-					}
-				},
-				"mdast-util-compact": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
-					"integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
-					"dev": true,
-					"requires": {
-						"unist-util-visit": "^2.0.0"
-					}
-				},
-				"parse-entities": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-					"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-					"dev": true,
-					"requires": {
-						"character-entities": "^1.0.0",
-						"character-entities-legacy": "^1.0.0",
-						"character-reference-invalid": "^1.0.0",
-						"is-alphanumerical": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-hexadecimal": "^1.0.0"
-					}
-				},
 				"remark": {
-					"version": "12.0.1",
-					"resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
-					"integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
+					"version": "13.0.0",
+					"resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
+					"integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
 					"dev": true,
 					"requires": {
-						"remark-parse": "^8.0.0",
-						"remark-stringify": "^8.0.0",
-						"unified": "^9.0.0"
+						"remark-parse": "^9.0.0",
+						"remark-stringify": "^9.0.0",
+						"unified": "^9.1.0"
 					}
 				},
 				"remark-parse": {
-					"version": "8.0.3",
-					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
-					"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+					"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
 					"dev": true,
 					"requires": {
-						"ccount": "^1.0.0",
-						"collapse-white-space": "^1.0.2",
-						"is-alphabetical": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-whitespace-character": "^1.0.0",
-						"is-word-character": "^1.0.0",
-						"markdown-escapes": "^1.0.0",
-						"parse-entities": "^2.0.0",
-						"repeat-string": "^1.5.4",
-						"state-toggle": "^1.0.0",
-						"trim": "0.0.1",
-						"trim-trailing-lines": "^1.0.0",
-						"unherit": "^1.0.4",
-						"unist-util-remove-position": "^2.0.0",
-						"vfile-location": "^3.0.0",
-						"xtend": "^4.0.1"
+						"mdast-util-from-markdown": "^0.8.0"
 					}
 				},
 				"remark-stringify": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
-					"integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+					"integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
 					"dev": true,
 					"requires": {
-						"ccount": "^1.0.0",
-						"is-alphanumeric": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-whitespace-character": "^1.0.0",
-						"longest-streak": "^2.0.1",
-						"markdown-escapes": "^1.0.0",
-						"markdown-table": "^2.0.0",
-						"mdast-util-compact": "^2.0.0",
-						"parse-entities": "^2.0.0",
-						"repeat-string": "^1.5.4",
-						"state-toggle": "^1.0.0",
-						"stringify-entities": "^3.0.0",
-						"unherit": "^1.0.4",
-						"xtend": "^4.0.1"
-					}
-				},
-				"stringify-entities": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
-					"integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
-					"dev": true,
-					"requires": {
-						"character-entities-html4": "^1.0.0",
-						"character-entities-legacy": "^1.0.0",
-						"is-alphanumerical": "^1.0.0",
-						"is-decimal": "^1.0.2",
-						"is-hexadecimal": "^1.0.0"
+						"mdast-util-to-markdown": "^0.6.0"
 					}
 				},
 				"unified": {
-					"version": "9.1.0",
-					"resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
-					"integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
+					"version": "9.2.1",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
+					"integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
 					"dev": true,
 					"requires": {
 						"bail": "^1.0.0",
@@ -2106,68 +3839,31 @@
 					}
 				},
 				"unist-util-find-all-after": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.1.tgz",
-					"integrity": "sha512-0GICgc++sRJesLwEYDjFVJPJttBpVQaTNgc6Jw0Jhzvfs+jtKePEMu+uD+PqkRUrAvGQqwhpDwLGWo1PK8PDEw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
+					"integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
 					"dev": true,
 					"requires": {
 						"unist-util-is": "^4.0.0"
 					}
 				},
 				"unist-util-is": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-					"integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+					"integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
 					"dev": true
 				},
-				"unist-util-remove-position": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
-					"integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
-					"dev": true,
-					"requires": {
-						"unist-util-visit": "^2.0.0"
-					}
-				},
-				"unist-util-visit": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-					"integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0",
-						"unist-util-visit-parents": "^3.0.0"
-					}
-				},
-				"unist-util-visit-parents": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
-					"integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
-					}
-				},
 				"vfile": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
-					"integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+					"integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
 					"dev": true,
 					"requires": {
 						"@types/unist": "^2.0.0",
 						"is-buffer": "^2.0.0",
-						"replace-ext": "1.0.0",
 						"unist-util-stringify-position": "^2.0.0",
 						"vfile-message": "^2.0.0"
 					}
-				},
-				"vfile-location": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
-					"integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ==",
-					"dev": true
 				}
 			}
 		},
@@ -2214,15 +3910,15 @@
 			"dev": true
 		},
 		"@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.4.0.tgz",
-			"integrity": "sha512-zLl4Fl3NvKxxjWNkqEcpdSOpQ3LGVH2BNFQ6vjaK6sFo2IrSznrhURIPI0HAphKiiIwNYjAfE0TNoQDSZv0U9A==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
+			"integrity": "sha512-q4jSH1UUvbrsOtlo/tKcgSeiCHRSBdXoIoqX1pgcKK/aU3JD27wmMKwGtpB8qRYUYoyXvfGxUVKchLuR5pB3rQ==",
 			"dev": true
 		},
 		"@svgr/babel-preset": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.4.0.tgz",
-			"integrity": "sha512-Gyx7cCxua04DBtyILTYdQxeO/pwfTBev6+eXTbVbxe4HTGhOUW6yo7PSbG2p6eJMl44j6XSequ0ZDP7bl0nu9A==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
+			"integrity": "sha512-4FiXBjvQ+z2j7yASeGPEi8VD/5rrGQk4Xrq3EdJmoZgz/tpqChpo5hgXDvmEauwtvOc52q8ghhZK4Oy7qph4ig==",
 			"dev": true,
 			"requires": {
 				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
@@ -2232,48 +3928,48 @@
 				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
 				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
 				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
-				"@svgr/babel-plugin-transform-svg-component": "^5.4.0"
+				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
 			}
 		},
 		"@svgr/core": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.4.0.tgz",
-			"integrity": "sha512-hWGm1DCCvd4IEn7VgDUHYiC597lUYhFau2lwJBYpQWDirYLkX4OsXu9IslPgJ9UpP7wsw3n2Ffv9sW7SXJVfqQ==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.5.0.tgz",
+			"integrity": "sha512-q52VOcsJPvV3jO1wkPtzTuKlvX7Y3xIcWRpCMtBF3MrteZJtBfQw/+u0B1BHy5ColpQc1/YVTrPEtSYIMNZlrQ==",
 			"dev": true,
 			"requires": {
-				"@svgr/plugin-jsx": "^5.4.0",
-				"camelcase": "^6.0.0",
-				"cosmiconfig": "^6.0.0"
+				"@svgr/plugin-jsx": "^5.5.0",
+				"camelcase": "^6.2.0",
+				"cosmiconfig": "^7.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 					"dev": true
 				},
 				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
 					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
+						"import-fresh": "^3.2.1",
 						"parse-json": "^5.0.0",
 						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
+						"yaml": "^1.10.0"
 					}
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -2286,59 +3982,323 @@
 			}
 		},
 		"@svgr/hast-util-to-babel-ast": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.4.0.tgz",
-			"integrity": "sha512-+U0TZZpPsP2V1WvVhqAOSTk+N+CjYHdZx+x9UBa1eeeZDXwH8pt0CrQf2+SvRl/h2CAPRFkm+Ey96+jKP8Bsgg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
+			"integrity": "sha512-cAaR/CAiZRB8GP32N+1jocovUtvlj0+e65TB50/6Lcime+EA49m/8l+P2ko+XPJ4dw3xaPS3jOL4F2X4KWxoeQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.9.5"
+				"@babel/types": "^7.12.6"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@svgr/plugin-jsx": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.4.0.tgz",
-			"integrity": "sha512-SGzO4JZQ2HvGRKDzRga9YFSqOqaNrgLlQVaGvpZ2Iht2gwRp/tq+18Pvv9kS9ZqOMYgyix2LLxZMY1LOe9NPqw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
+			"integrity": "sha512-V/wVh33j12hGh05IDg8GpIUXbjAPnTdPTKuP4VNLggnwaHMPNQNae2pRnyTAILWCQdz5GyMqtO488g7CKM8CBA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.7.5",
-				"@svgr/babel-preset": "^5.4.0",
-				"@svgr/hast-util-to-babel-ast": "^5.4.0",
+				"@babel/core": "^7.12.3",
+				"@svgr/babel-preset": "^5.5.0",
+				"@svgr/hast-util-to-babel-ast": "^5.5.0",
 				"svg-parser": "^2.0.2"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/core": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+					"integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-compilation-targets": "^7.13.13",
+						"@babel/helper-module-transforms": "^7.13.14",
+						"@babel/helpers": "^7.13.10",
+						"@babel/parser": "^7.13.13",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.1.2",
+						"semver": "^6.3.0",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/helpers": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+					"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"gensync": {
+					"version": "1.0.0-beta.2",
+					"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+					"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@svgr/plugin-svgo": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.4.0.tgz",
-			"integrity": "sha512-3Cgv3aYi1l6SHyzArV9C36yo4kgwVdF3zPQUC6/aCDUeXAofDYwE5kk3e3oT5ZO2a0N3lB+lLGvipBG6lnG8EA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
+			"integrity": "sha512-r5swKk46GuQl4RrVejVwpeeJaydoxkdwkM1mBKOgJLBUJPGaLci6ylg/IjhrRsREKDkr4kbMWdgOtbXEh0fyLQ==",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^6.0.0",
-				"merge-deep": "^3.0.2",
+				"cosmiconfig": "^7.0.0",
+				"deepmerge": "^4.2.2",
 				"svgo": "^1.2.2"
 			},
 			"dependencies": {
 				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
 					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
+						"import-fresh": "^3.2.1",
 						"parse-json": "^5.0.0",
 						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
+						"yaml": "^1.10.0"
 					}
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -2351,19 +4311,264 @@
 			}
 		},
 		"@svgr/webpack": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.4.0.tgz",
-			"integrity": "sha512-LjepnS/BSAvelnOnnzr6Gg0GcpLmnZ9ThGFK5WJtm1xOqdBE/1IACZU7MMdVzjyUkfFqGz87eRE4hFaSLiUwYg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-5.5.0.tgz",
+			"integrity": "sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.9.0",
-				"@babel/plugin-transform-react-constant-elements": "^7.9.0",
-				"@babel/preset-env": "^7.9.5",
-				"@babel/preset-react": "^7.9.4",
-				"@svgr/core": "^5.4.0",
-				"@svgr/plugin-jsx": "^5.4.0",
-				"@svgr/plugin-svgo": "^5.4.0",
+				"@babel/core": "^7.12.3",
+				"@babel/plugin-transform-react-constant-elements": "^7.12.1",
+				"@babel/preset-env": "^7.12.1",
+				"@babel/preset-react": "^7.12.5",
+				"@svgr/core": "^5.5.0",
+				"@svgr/plugin-jsx": "^5.5.0",
+				"@svgr/plugin-svgo": "^5.5.0",
 				"loader-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/core": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+					"integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-compilation-targets": "^7.13.13",
+						"@babel/helper-module-transforms": "^7.13.14",
+						"@babel/helpers": "^7.13.10",
+						"@babel/parser": "^7.13.13",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.1.2",
+						"semver": "^6.3.0",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/helpers": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+					"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"gensync": {
+					"version": "1.0.0-beta.2",
+					"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+					"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@types/anymatch": {
@@ -2373,9 +4578,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.1.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-			"integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+			"version": "7.1.14",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+			"integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2386,18 +4591,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2405,12 +4610,21 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-			"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+			"integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/cheerio": {
+			"version": "0.22.28",
+			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.28.tgz",
+			"integrity": "sha512-ehUMGSW5IeDxJjbru4awKYMlKGmo1wSSGUVqXtYwlgmUM8X1a0PZttEIm6yEY7vHsY/hh6iPnklF213G0UColw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
 			}
 		},
 		"@types/color-name": {
@@ -2430,9 +4644,9 @@
 			}
 		},
 		"@types/graceful-fs": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+			"integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -2454,26 +4668,34 @@
 			}
 		},
 		"@types/istanbul-reports": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+			"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
 			"dev": true
 		},
-		"@types/mime-types": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-			"integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
 			"dev": true
+		},
+		"@types/mdast": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
+			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "*"
+			}
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -2482,9 +4704,9 @@
 			"dev": true
 		},
 		"@types/minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
 			"dev": true
 		},
 		"@types/node": {
@@ -2506,15 +4728,47 @@
 			"dev": true
 		},
 		"@types/prettier": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
-			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+			"integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
+			"dev": true
+		},
+		"@types/prop-types": {
+			"version": "15.7.3",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
 			"dev": true
 		},
 		"@types/q": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
 			"integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
+			"dev": true
+		},
+		"@types/react": {
+			"version": "16.14.5",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz",
+			"integrity": "sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==",
+			"dev": true,
+			"requires": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "*",
+				"csstype": "^3.0.2"
+			}
+		},
+		"@types/react-dom": {
+			"version": "16.9.12",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.12.tgz",
+			"integrity": "sha512-i7NPZZpPte3jtVOoW+eLB7G/jsX5OM6GqQnH+lC0nq0rqwlK0x8WcMEvYDgFWqWhWMlTltTimzdMax6wYfZssA==",
+			"dev": true,
+			"requires": {
+				"@types/react": "^16"
+			}
+		},
+		"@types/scheduler": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+			"integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
 			"dev": true
 		},
 		"@types/source-list-map": {
@@ -2524,21 +4778,21 @@
 			"dev": true
 		},
 		"@types/stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+			"integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
 			"dev": true
 		},
 		"@types/tapable": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
-			"integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
+			"integrity": "sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==",
 			"dev": true
 		},
 		"@types/uglify-js": {
-			"version": "3.9.3",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-			"integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.0.tgz",
+			"integrity": "sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==",
 			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
@@ -2571,23 +4825,23 @@
 			}
 		},
 		"@types/webpack": {
-			"version": "4.41.21",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-			"integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+			"version": "4.41.27",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
+			"integrity": "sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==",
 			"dev": true,
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
-				"@types/tapable": "*",
+				"@types/tapable": "^1",
 				"@types/uglify-js": "*",
 				"@types/webpack-sources": "*",
 				"source-map": "^0.6.0"
 			}
 		},
 		"@types/webpack-sources": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
-			"integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz",
+			"integrity": "sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -2604,18 +4858,18 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "15.0.5",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-			"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+			"version": "15.0.13",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+			"integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+			"version": "20.2.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
 			"dev": true
 		},
 		"@types/yauzl": {
@@ -2628,31 +4882,158 @@
 				"@types/node": "*"
 			}
 		},
+		"@typescript-eslint/eslint-plugin": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.21.0.tgz",
+			"integrity": "sha512-FPUyCPKZbVGexmbCFI3EQHzCZdy2/5f+jv6k2EDljGdXSRc0cKvbndd2nHZkSLqCNOPk0jB6lGzwIkglXcYVsQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "4.21.0",
+				"@typescript-eslint/scope-manager": "4.21.0",
+				"debug": "^4.1.1",
+				"functional-red-black-tree": "^1.0.1",
+				"lodash": "^4.17.15",
+				"regexpp": "^3.0.0",
+				"semver": "^7.3.2",
+				"tsutils": "^3.17.1"
+			}
+		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-			"integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.21.0.tgz",
+			"integrity": "sha512-cEbgosW/tUFvKmkg3cU7LBoZhvUs+ZPVM9alb25XvR0dal4qHL3SiUqHNrzoWSxaXA9gsifrYrS1xdDV6w/gIA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.34.0",
+				"@typescript-eslint/scope-manager": "4.21.0",
+				"@typescript-eslint/types": "4.21.0",
+				"@typescript-eslint/typescript-estree": "4.21.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
 			}
 		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-			"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+		"@typescript-eslint/parser": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.21.0.tgz",
+			"integrity": "sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==",
 			"dev": true,
 			"requires": {
+				"@typescript-eslint/scope-manager": "4.21.0",
+				"@typescript-eslint/types": "4.21.0",
+				"@typescript-eslint/typescript-estree": "4.21.0",
+				"debug": "^4.1.1"
+			}
+		},
+		"@typescript-eslint/scope-manager": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz",
+			"integrity": "sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.21.0",
+				"@typescript-eslint/visitor-keys": "4.21.0"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.21.0.tgz",
+			"integrity": "sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz",
+			"integrity": "sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.21.0",
+				"@typescript-eslint/visitor-keys": "4.21.0",
 				"debug": "^4.1.1",
-				"eslint-visitor-keys": "^1.1.0",
-				"glob": "^7.1.6",
+				"globby": "^11.0.1",
 				"is-glob": "^4.0.1",
-				"lodash": "^4.17.15",
 				"semver": "^7.3.2",
 				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.0",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+					"integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz",
+			"integrity": "sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.21.0",
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"dev": true
+				}
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -2901,72 +5282,350 @@
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.7.0.tgz",
-			"integrity": "sha512-yR+rSyfHKfevW84vKBOERpjEslD/o00CaYMftywVYOjsOQ8GLS6xv/VgDcpQ8JomJ9eRRInLRpeGKTM3lOa4xQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.2.tgz",
+			"integrity": "sha512-l/6TRs0oZATS5s3mZhMg79tLcyyosiszdD0Om149c+rEgZ2PJS1vGgrNJvGiU5yj+42Xuz7196IZ0zbXjy8aUQ==",
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.17.0.tgz",
-			"integrity": "sha512-9SvyQIC2oYerc+zsZJtQH/P8KqKOJJJH+QrmCIrD2PQ1cw9QrF456sV/xHuNfaAoV3QGFLxP+0wVFOLKdU22DQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-5.2.0.tgz",
+			"integrity": "sha512-5nRUbA105bEx0U5/CpRBXM4T1UR37Q89PPy7Wed7t2r9ECADjtUTyIwCwjuDHfYMKOS3YL5NDXbMMVpS3cQlUQ==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.9.0",
-				"@babel/plugin-transform-react-jsx": "^7.9.4",
-				"@babel/plugin-transform-runtime": "^7.9.0",
-				"@babel/preset-env": "^7.9.0",
-				"@babel/runtime": "^7.9.2",
-				"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
-				"@wordpress/browserslist-config": "^2.7.0",
-				"@wordpress/element": "^2.16.0",
-				"@wordpress/warning": "^1.2.0",
+				"@babel/core": "^7.13.10",
+				"@babel/plugin-transform-react-jsx": "^7.12.7",
+				"@babel/plugin-transform-runtime": "^7.13.10",
+				"@babel/preset-env": "^7.13.10",
+				"@babel/preset-typescript": "^7.13.0",
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^3.0.2",
+				"@wordpress/browserslist-config": "^3.0.2",
+				"@wordpress/element": "^2.20.1",
+				"@wordpress/warning": "^1.4.1",
 				"core-js": "^3.6.4"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"@babel/core": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+					"integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-compilation-targets": "^7.13.13",
+						"@babel/helper-module-transforms": "^7.13.14",
+						"@babel/helpers": "^7.13.10",
+						"@babel/parser": "^7.13.13",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.1.2",
+						"semver": "^6.3.0",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.13.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+					"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+					"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.13",
+						"@babel/template": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+					"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+					"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+					"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+					"integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.13.12",
+						"@babel/helper-replace-supers": "^7.13.12",
+						"@babel/helper-simple-access": "^7.13.12",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.13",
+						"@babel/types": "^7.13.14"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+					"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+					"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.13.12",
+						"@babel/helper-optimise-call-expression": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.13.12",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+					"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.13.12"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+					"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/helpers": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+					"integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.12.13",
+						"@babel/traverse": "^7.13.0",
+						"@babel/types": "^7.13.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+					"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+					"integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+					"dev": true
+				},
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@babel/template": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+					"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/parser": "^7.12.13",
+						"@babel/types": "^7.12.13"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.13.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+					"integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@babel/generator": "^7.13.9",
+						"@babel/helper-function-name": "^7.12.13",
+						"@babel/helper-split-export-declaration": "^7.12.13",
+						"@babel/parser": "^7.13.13",
+						"@babel/types": "^7.13.13",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.13.14",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+					"integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"gensync": {
+					"version": "1.0.0-beta.2",
+					"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+					"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+					"dev": true
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.0.1.tgz",
-			"integrity": "sha512-nwm0OK/AkxkTkdvZTMeBxkO01RXFYP8TXdqAsx6Fn022o7YV40V89yLr7zTRoQ8MSNy6c/WmRxnLKapLdUCDUg==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.4.1.tgz",
+			"integrity": "sha512-H2a/jzcTEQcYYn+pFPQ8FGrfRGN+qPESyrrF3w+ty8SM4/+xH/Kn5mos/a8/7lGA/ChYeSC5b1lnO19E3gvPcQ==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
-			"integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.2.tgz",
+			"integrity": "sha512-xtqeXdeGzC8DUE5eSYNKrLkUy8kihoakOe3W/jq3QLnIfTCtjK1jBFV/vk9fge9QuvUcOCiWP1bDxBeYKXgQHA==",
 			"dev": true
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-2.8.0.tgz",
-			"integrity": "sha512-fEOsSl1kYY8gkiAe7OM9IopmSOtaAug37OQwKVeda5fK6xLsnpqprP5iwHHOApNWMEzgmVGS6/iW5IZoi7qv/A==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.1.tgz",
+			"integrity": "sha512-gLp6DMYlXO+0RZECjFCoKJvN4wmZDV0WCrQBwfXmBsieod97pNYr/xABpkAkg6XoR9/LZ1f18M3xsgrCWGrxNQ==",
 			"dev": true,
 			"requires": {
 				"json2php": "^0.0.4",
-				"webpack": "^4.8.3",
-				"webpack-sources": "^1.3.0"
+				"webpack-sources": "^2.2.0"
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.16.0.tgz",
-			"integrity": "sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==",
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.1.tgz",
+			"integrity": "sha512-aHfv3rnY8yea3VvfabPpyQXuYTQLKMcOSRxG+ydxptQNlQjEBe+KtCXyqr5g7bpqEBT5waFSr3IbJKk+G+hZxA==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"@wordpress/escape-html": "^1.9.0",
-				"lodash": "^4.17.15",
-				"react": "^16.9.0",
-				"react-dom": "^16.9.0"
+				"@babel/runtime": "^7.13.10",
+				"@types/react": "^16.9.0",
+				"@types/react-dom": "^16.9.0",
+				"@wordpress/escape-html": "^1.12.1",
+				"lodash": "^4.17.19",
+				"react": "^16.13.1",
+				"react-dom": "^16.13.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.9.0.tgz",
-			"integrity": "sha512-XW0GGqxpFauOgTjfQ9603hCDnUE+HhD0HVFMIEphIrTpTreLW3lJbfTibPTn0dWWPATqanH2TlPurOagUubh4g==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.1.tgz",
+			"integrity": "sha512-moudz8yUXiI2dGi+OWcNxKffbpF7B+XCG0dt9W3HRzSwalWAeo4CNzA5wSve1BYk8wMX8BiSGO+8ew+2Yr+cug==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.9.2"
+				"@babel/runtime": "^7.13.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -2983,144 +5642,256 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.7.0.tgz",
-			"integrity": "sha512-+PLH0jbY7xuKJckrkbtRk7zfyg4YDHFVulqydEBzSiU+LsZ2f/9hdRbb4/JDUneG7NpROO2smqxmaACxu5o9gw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.0.2.tgz",
+			"integrity": "sha512-EFDdRd53zzB2Nf+QGkGGs6woR6m4KUgWU/bGAU0f5g9p3oe8kgj6Tbdy02TKI+yfCDiKNlgEDh09u52Hz0w7vg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"jest-matcher-utils": "^25.3.0",
-				"lodash": "^4.17.15"
+				"@babel/runtime": "^7.13.10",
+				"jest-matcher-utils": "^26.6.2",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-6.2.0.tgz",
-			"integrity": "sha512-o8Yu+DnBWVXTLrbKYwWMRuF56quMiEK7+A9LSBQNrQ8PejTomhTF7lw8aGsUb7KdPgjbL941tbxVNJ/mKcbaJw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.0.2.tgz",
+			"integrity": "sha512-biEKSoiHwopjw1yYY24T/yI44Z3ExCdeHHIHbztcYNcgEB1IcObZ4WKVGRxftcmkaP6TEce3sxX62D+PBNwCQg==",
 			"dev": true,
 			"requires": {
-				"@jest/reporters": "^25.3.0",
-				"@wordpress/jest-console": "^3.7.0",
-				"babel-jest": "^25.3.0",
+				"@wordpress/jest-console": "^4.0.2",
+				"babel-jest": "^26.6.3",
 				"enzyme": "^3.11.0",
 				"enzyme-adapter-react-16": "^1.15.2",
 				"enzyme-to-json": "^3.4.4"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-3.1.0.tgz",
-			"integrity": "sha512-SYRWpzpQaSsBUiRO+ssqg6AHjgCF4j2npstGTGaKdVs/B720fLFzeyONuMmo1ZtMb9v6MyEWxVz5ON6dDgmVYg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.2.tgz",
+			"integrity": "sha512-C3v9rxHfXXqRoaCYv8lu4C0g8KHIvEs5JqFjRroW1bpe1yC/f9YSVj04mlwsSgtHUwPcDQZ5osQec4gDs5/nGw==",
 			"dev": true
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.3.1.tgz",
-			"integrity": "sha512-BNZhZwUB0r1OQ+5J89foptarBRnjY+a8F4LtoeY2iMUbAYvT+Y6lkIyJOp5NR6oyeiV9IT1Tcih9ViqZlR+c+w==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-2.1.1.tgz",
+			"integrity": "sha512-TAl0EIu3psL8neWdtvHz8ValknhUkTlPyOMogPaJozmKKfhIKWxZPEO0+5iyevdZ9+U4kQY+j9hVAHUW4tRVZg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^2.0.1",
-				"@wordpress/postcss-themes": "^2.6.0",
-				"autoprefixer": "^9.4.5",
-				"postcss-custom-properties": "^9.1.1"
+				"@wordpress/base-styles": "^3.4.1",
+				"@wordpress/postcss-themes": "^3.0.2",
+				"autoprefixer": "^9.8.6",
+				"postcss-custom-properties": "^10.0.0"
+			},
+			"dependencies": {
+				"autoprefixer": {
+					"version": "9.8.6",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+					"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.12.0",
+						"caniuse-lite": "^1.0.30001109",
+						"colorette": "^1.2.1",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^7.0.32",
+						"postcss-value-parser": "^4.1.0"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001207",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+					"integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/postcss-themes": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-2.6.0.tgz",
-			"integrity": "sha512-Q22s1KSVdtoK0Z0ND06V2QwTx/U4KvJhWFmoI8IzYW/LGlk8BkQJhHH157Y9vFliwpMlQpqfXW6/zOg2XtvHzQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-themes/-/postcss-themes-3.0.2.tgz",
+			"integrity": "sha512-8hmGYKKKtK0SzL+nnSuFNkpd9Ffq57NKtusyc99WvNMiYdDeTXLWulQzlgzrT8tx7Ss8MuPSM7yH3bHI3h1CTA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.32"
 			}
 		},
 		"@wordpress/prettier-config": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-0.3.0.tgz",
-			"integrity": "sha512-wL1ztV+so5Ttwz23lDmb8ZmREmND96sf+Dh/kbP2nyAw/DWt3K8uj31qbczVmjwfoetTiRoH9Z1CasgPs4bccg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.0.2.tgz",
+			"integrity": "sha512-puyOhbJuMjUeo2EcHmmh88mk0BFAUMTXWKyzJ0y3hlPXaPnjXdir/trj2hrI9FvWTnygLWU98qxhQUfhbIhPdw==",
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.1.1.tgz",
-			"integrity": "sha512-PC8M9h6LkNJgzbRIVBuZrAchVNaEaWPSF47yljKRrg01xWlPtWRQwWWoYvleHuBrLozSElJYrA73W8d/vPPrtg==",
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-14.1.0.tgz",
+			"integrity": "sha512-WZkgcAMq1UPOJCyYyfuUC5qWFUxXHIUxKU8NR3D+x5Yr27KvG5aeEiDTHyJHkIhmN01diB3Sq+ybnncm4V5oaA==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
-				"@wordpress/babel-preset-default": "^4.17.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
-				"@wordpress/eslint-plugin": "^7.1.0",
-				"@wordpress/jest-preset-default": "^6.2.0",
-				"@wordpress/npm-package-json-lint-config": "^3.1.0",
-				"@wordpress/postcss-plugins-preset": "^1.3.1",
-				"@wordpress/prettier-config": "^0.3.0",
-				"babel-jest": "^25.3.0",
-				"babel-loader": "^8.1.0",
+				"@wordpress/babel-preset-default": "^5.2.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^3.1.1",
+				"@wordpress/eslint-plugin": "^9.0.2",
+				"@wordpress/jest-preset-default": "^7.0.2",
+				"@wordpress/npm-package-json-lint-config": "^4.0.2",
+				"@wordpress/postcss-plugins-preset": "^2.1.1",
+				"@wordpress/prettier-config": "^1.0.2",
+				"@wordpress/stylelint-config": "^19.0.2",
+				"babel-jest": "^26.6.3",
+				"babel-loader": "^8.2.2",
 				"chalk": "^4.0.0",
-				"check-node-version": "^3.1.1",
+				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
 				"cross-spawn": "^5.1.0",
 				"css-loader": "^3.5.2",
+				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^7.1.0",
+				"eslint": "^7.17.0",
 				"eslint-plugin-markdown": "^1.0.2",
-				"ignore-emit-webpack-plugin": "^2.0.2",
-				"jest": "^25.3.0",
-				"jest-puppeteer": "^4.4.0",
+				"expect-puppeteer": "^4.4.0",
+				"file-loader": "^6.2.0",
+				"ignore-emit-webpack-plugin": "^2.0.6",
+				"jest": "^26.6.3",
+				"jest-dev-server": "^4.4.0",
+				"jest-environment-node": "^26.6.2",
 				"markdownlint": "^0.18.0",
 				"markdownlint-cli": "^0.21.0",
+				"merge-deep": "^3.0.3",
 				"mini-css-extract-plugin": "^0.9.0",
 				"minimist": "^1.2.0",
-				"node-sass": "^4.13.1",
 				"npm-package-json-lint": "^5.0.0",
 				"postcss-loader": "^3.0.0",
-				"prettier": "npm:wp-prettier@2.0.5",
-				"puppeteer": "npm:puppeteer-core@3.0.0",
+				"prettier": "npm:wp-prettier@2.2.1-beta-1",
+				"puppeteer-core": "^5.5.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
+				"sass": "^1.26.11",
 				"sass-loader": "^8.0.2",
 				"source-map-loader": "^0.2.4",
-				"stylelint": "^13.6.0",
-				"stylelint-config-wordpress": "^17.0.0",
+				"stylelint": "^13.8.0",
 				"terser-webpack-plugin": "^3.0.3",
 				"thread-loader": "^2.1.3",
 				"url-loader": "^3.0.0",
 				"webpack": "^4.42.0",
-				"webpack-bundle-analyzer": "^3.6.1",
+				"webpack-bundle-analyzer": "^4.2.0",
 				"webpack-cli": "^3.3.11",
-				"webpack-livereload-plugin": "^2.3.0"
+				"webpack-livereload-plugin": "^2.3.0",
+				"webpack-sources": "^2.2.0"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.13.10",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+					"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
 				"@nodelib/fs.stat": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 					"dev": true
 				},
 				"@wordpress/eslint-plugin": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.1.0.tgz",
-					"integrity": "sha512-FTrKkpEa8vZg7/7M6GBhd1YW24hnh5rFGzKgKX4MGyB0Jw8GGSwld9J23eRbQ5JQWGFP/tmOMeiu6W1/arxy7Q==",
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.0.2.tgz",
+					"integrity": "sha512-XmD2jpxmFoAFJgxaMuKs2zT1fGsZQGWLFgc7zENOw7EFKwDNP4o8YqsU6IbkSfX0QTSqB+D91Tq1B6HBq9FCxA==",
 					"dev": true,
 					"requires": {
-						"@wordpress/prettier-config": "^0.3.0",
+						"@typescript-eslint/eslint-plugin": "^4.15.0",
+						"@typescript-eslint/parser": "^4.15.0",
+						"@wordpress/prettier-config": "^1.0.2",
 						"babel-eslint": "^10.1.0",
-						"eslint-config-prettier": "^6.10.1",
-						"eslint-plugin-jest": "^23.8.2",
-						"eslint-plugin-jsdoc": "^26.0.0",
-						"eslint-plugin-jsx-a11y": "^6.2.3",
-						"eslint-plugin-prettier": "^3.1.2",
-						"eslint-plugin-react": "^7.20.0",
-						"eslint-plugin-react-hooks": "^4.0.4",
+						"cosmiconfig": "^7.0.0",
+						"eslint-config-prettier": "^7.1.0",
+						"eslint-plugin-import": "^2.22.1",
+						"eslint-plugin-jest": "^24.1.3",
+						"eslint-plugin-jsdoc": "^30.7.13",
+						"eslint-plugin-jsx-a11y": "^6.4.1",
+						"eslint-plugin-prettier": "^3.3.0",
+						"eslint-plugin-react": "^7.22.0",
+						"eslint-plugin-react-hooks": "^4.2.0",
 						"globals": "^12.0.0",
-						"prettier": "npm:wp-prettier@2.0.5",
+						"prettier": "npm:wp-prettier@2.2.1-beta-1",
 						"requireindex": "^1.2.0"
+					}
+				},
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+					"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
 					}
 				},
 				"array-union": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"array.prototype.flatmap": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+					"integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.1",
+						"function-bind": "^1.1.1"
+					}
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"autoprefixer": {
+					"version": "9.8.6",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+					"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.12.0",
+						"caniuse-lite": "^1.0.30001109",
+						"colorette": "^1.2.1",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^7.0.32",
+						"postcss-value-parser": "^4.1.0"
+					}
+				},
+				"axe-core": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.4.tgz",
+					"integrity": "sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==",
 					"dev": true
 				},
 				"camelcase": {
@@ -3140,31 +5911,38 @@
 						"quick-lru": "^4.0.1"
 					}
 				},
+				"caniuse-lite": {
+					"version": "1.0.30001207",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+					"integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
 				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+					"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
 					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
+						"import-fresh": "^3.2.1",
 						"parse-json": "^5.0.0",
 						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
-					},
-					"dependencies": {
-						"parse-json": {
-							"version": "5.0.1",
-							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-							"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
-							"dev": true,
-							"requires": {
-								"@babel/code-frame": "^7.0.0",
-								"error-ex": "^1.3.1",
-								"json-parse-better-errors": "^1.0.1",
-								"lines-and-columns": "^1.1.6"
-							}
-						}
+						"yaml": "^1.10.0"
 					}
 				},
 				"cross-spawn": {
@@ -3187,22 +5965,287 @@
 						"path-type": "^4.0.0"
 					}
 				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
 				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 					"dev": true
+				},
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					}
+				},
+				"eslint": {
+					"version": "7.23.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
+					"integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "7.12.11",
+						"@eslint/eslintrc": "^0.4.0",
+						"ajv": "^6.10.0",
+						"chalk": "^4.0.0",
+						"cross-spawn": "^7.0.2",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"enquirer": "^2.3.5",
+						"eslint-scope": "^5.1.1",
+						"eslint-utils": "^2.1.0",
+						"eslint-visitor-keys": "^2.0.0",
+						"espree": "^7.3.1",
+						"esquery": "^1.4.0",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^6.0.1",
+						"functional-red-black-tree": "^1.0.1",
+						"glob-parent": "^5.0.0",
+						"globals": "^13.6.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
+						"imurmurhash": "^0.1.4",
+						"is-glob": "^4.0.0",
+						"js-yaml": "^3.13.1",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.4.1",
+						"lodash": "^4.17.21",
+						"minimatch": "^3.0.4",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.9.1",
+						"progress": "^2.0.0",
+						"regexpp": "^3.1.0",
+						"semver": "^7.2.1",
+						"strip-ansi": "^6.0.0",
+						"strip-json-comments": "^3.1.0",
+						"table": "^6.0.4",
+						"text-table": "^0.2.0",
+						"v8-compile-cache": "^2.0.3"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+							"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.10.4"
+							}
+						},
+						"cross-spawn": {
+							"version": "7.0.3",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+							"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+							"dev": true,
+							"requires": {
+								"path-key": "^3.1.0",
+								"shebang-command": "^2.0.0",
+								"which": "^2.0.1"
+							}
+						},
+						"doctrine": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+							"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2"
+							}
+						},
+						"globals": {
+							"version": "13.7.0",
+							"resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+							"integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+							"dev": true,
+							"requires": {
+								"type-fest": "^0.20.2"
+							}
+						},
+						"shebang-command": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+							"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+							"dev": true,
+							"requires": {
+								"shebang-regex": "^3.0.0"
+							}
+						},
+						"shebang-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+							"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+							"dev": true
+						},
+						"which": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+							"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+							"dev": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
+					}
+				},
+				"eslint-plugin-jsx-a11y": {
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+					"integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.11.2",
+						"aria-query": "^4.2.2",
+						"array-includes": "^3.1.1",
+						"ast-types-flow": "^0.0.7",
+						"axe-core": "^4.0.2",
+						"axobject-query": "^2.2.0",
+						"damerau-levenshtein": "^1.0.6",
+						"emoji-regex": "^9.0.0",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^3.1.0",
+						"language-tags": "^1.0.5"
+					}
+				},
+				"eslint-plugin-react": {
+					"version": "7.23.1",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.23.1.tgz",
+					"integrity": "sha512-MvFGhZjI8Z4HusajmSw0ougGrq3Gs4vT/0WgwksZgf5RrLrRa2oYAw56okU4tZJl8+j7IYNuTM+2RnFEuTSdRQ==",
+					"dev": true,
+					"requires": {
+						"array-includes": "^3.1.3",
+						"array.prototype.flatmap": "^1.2.4",
+						"doctrine": "^2.1.0",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+						"minimatch": "^3.0.4",
+						"object.entries": "^1.1.3",
+						"object.fromentries": "^2.0.4",
+						"object.values": "^1.1.3",
+						"prop-types": "^15.7.2",
+						"resolve": "^2.0.0-next.3",
+						"string.prototype.matchall": "^4.0.4"
+					},
+					"dependencies": {
+						"array-includes": {
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+							"integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+							"dev": true,
+							"requires": {
+								"call-bind": "^1.0.2",
+								"define-properties": "^1.1.3",
+								"es-abstract": "^1.18.0-next.2",
+								"get-intrinsic": "^1.1.1",
+								"is-string": "^1.0.5"
+							}
+						}
+					}
 				},
 				"eslint-plugin-react-hooks": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz",
-					"integrity": "sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+					"integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
 					"dev": true
 				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+					"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+					"dev": true
+				},
+				"espree": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+					"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.4.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^1.3.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+							"dev": true
+						}
+					}
+				},
+				"esquery": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+					"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.1.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
 				"fast-glob": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
@@ -3211,6 +6254,15 @@
 						"merge2": "^1.3.0",
 						"micromatch": "^4.0.2",
 						"picomatch": "^2.2.1"
+					}
+				},
+				"file-entry-cache": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+					"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^3.0.4"
 					}
 				},
 				"find-up": {
@@ -3223,6 +6275,22 @@
 						"pinkie-promise": "^2.0.0"
 					}
 				},
+				"flat-cache": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+					"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+					"dev": true,
+					"requires": {
+						"flatted": "^3.1.0",
+						"rimraf": "^3.0.2"
+					}
+				},
+				"flatted": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+					"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+					"dev": true
+				},
 				"get-stdin": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
@@ -3230,9 +6298,9 @@
 					"dev": true
 				},
 				"globby": {
-					"version": "11.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+					"integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
 					"dev": true,
 					"requires": {
 						"array-union": "^2.1.0",
@@ -3241,12 +6309,52 @@
 						"ignore": "^5.1.4",
 						"merge2": "^1.3.0",
 						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"ignore": {
+							"version": "5.1.8",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+							"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+							"dev": true
+						}
 					}
 				},
-				"ignore": {
-					"version": "5.1.8",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+					"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+							"dev": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true
+						}
+					}
+				},
+				"ignore-emit-webpack-plugin": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
+					"integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
 					"dev": true
 				},
 				"indent-string": {
@@ -3255,16 +6363,74 @@
 					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 					"dev": true
 				},
+				"internal-slot": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+					"dev": true,
+					"requires": {
+						"get-intrinsic": "^1.1.0",
+						"has": "^1.0.3",
+						"side-channel": "^1.0.4"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"jsx-ast-utils": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
+					"integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+					"dev": true,
+					"requires": {
+						"array-includes": "^3.1.2",
+						"object.assign": "^4.1.2"
+					},
+					"dependencies": {
+						"array-includes": {
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+							"integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+							"dev": true,
+							"requires": {
+								"call-bind": "^1.0.2",
+								"define-properties": "^1.1.3",
+								"es-abstract": "^1.18.0-next.2",
+								"get-intrinsic": "^1.1.1",
+								"is-string": "^1.0.5"
+							}
+						}
+					}
+				},
 				"known-css-properties": {
-					"version": "0.19.0",
-					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
-					"integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
+					"version": "0.21.0",
+					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
+					"integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
 					"dev": true
 				},
 				"load-json-file": {
@@ -3278,6 +6444,17 @@
 						"pify": "^2.0.0",
 						"pinkie-promise": "^2.0.0",
 						"strip-bom": "^2.0.0"
+					},
+					"dependencies": {
+						"parse-json": {
+							"version": "2.2.0",
+							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+							"dev": true,
+							"requires": {
+								"error-ex": "^1.2.0"
+							}
+						}
 					}
 				},
 				"locate-path": {
@@ -3289,13 +6466,20 @@
 						"p-locate": "^4.1.0"
 					}
 				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+					"dev": true
+				},
 				"log-symbols": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-					"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+					"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^4.0.0"
+						"chalk": "^4.1.0",
+						"is-unicode-supported": "^0.1.0"
 					}
 				},
 				"lru-cache": {
@@ -3309,28 +6493,29 @@
 					}
 				},
 				"map-obj": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-					"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+					"integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
 					"dev": true
 				},
 				"meow": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
-					"integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
 					"dev": true,
 					"requires": {
 						"@types/minimist": "^1.2.0",
 						"camelcase-keys": "^6.2.2",
+						"decamelize": "^1.2.0",
 						"decamelize-keys": "^1.1.0",
 						"hard-rejection": "^2.1.0",
 						"minimist-options": "4.1.0",
-						"normalize-package-data": "^2.5.0",
+						"normalize-package-data": "^3.0.0",
 						"read-pkg-up": "^7.0.1",
 						"redent": "^3.0.0",
 						"trim-newlines": "^3.0.0",
-						"type-fest": "^0.13.1",
-						"yargs-parser": "^18.1.3"
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
 					},
 					"dependencies": {
 						"find-up": {
@@ -3343,16 +6528,25 @@
 								"path-exists": "^4.0.0"
 							}
 						},
-						"parse-json": {
-							"version": "5.0.1",
-							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-							"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+						"lru-cache": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+							"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 							"dev": true,
 							"requires": {
-								"@babel/code-frame": "^7.0.0",
-								"error-ex": "^1.3.1",
-								"json-parse-better-errors": "^1.0.1",
-								"lines-and-columns": "^1.1.6"
+								"yallist": "^4.0.0"
+							}
+						},
+						"normalize-package-data": {
+							"version": "3.0.2",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+							"integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^4.0.1",
+								"resolve": "^1.20.0",
+								"semver": "^7.3.4",
+								"validate-npm-package-license": "^3.0.1"
 							}
 						},
 						"path-exists": {
@@ -3373,6 +6567,30 @@
 								"type-fest": "^0.6.0"
 							},
 							"dependencies": {
+								"hosted-git-info": {
+									"version": "2.8.8",
+									"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+									"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+									"dev": true
+								},
+								"normalize-package-data": {
+									"version": "2.5.0",
+									"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+									"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+									"dev": true,
+									"requires": {
+										"hosted-git-info": "^2.1.4",
+										"resolve": "^1.10.0",
+										"semver": "2 || 3 || 4 || 5",
+										"validate-npm-package-license": "^3.0.1"
+									}
+								},
+								"semver": {
+									"version": "5.7.1",
+									"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+									"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+									"dev": true
+								},
 								"type-fest": {
 									"version": "0.6.0",
 									"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -3399,6 +6617,37 @@
 									"dev": true
 								}
 							}
+						},
+						"resolve": {
+							"version": "1.20.0",
+							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+							"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+							"dev": true,
+							"requires": {
+								"is-core-module": "^2.2.0",
+								"path-parse": "^1.0.6"
+							}
+						},
+						"semver": {
+							"version": "7.3.5",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+							"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
+						},
+						"type-fest": {
+							"version": "0.18.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+							"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+							"dev": true
+						},
+						"yallist": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+							"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+							"dev": true
 						}
 					}
 				},
@@ -3411,6 +6660,60 @@
 						"arrify": "^1.0.1",
 						"is-plain-obj": "^1.1.0",
 						"kind-of": "^6.0.3"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"object.entries": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+					"integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.1",
+						"has": "^1.0.3"
+					}
+				},
+				"object.fromentries": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
+					"integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2",
+						"has": "^1.0.3"
+					}
+				},
+				"object.values": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+					"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2",
+						"has": "^1.0.3"
 					}
 				},
 				"p-limit": {
@@ -3438,12 +6741,15 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-even-better-errors": "^2.3.0",
+						"lines-and-columns": "^1.1.6"
 					}
 				},
 				"path-exists": {
@@ -3467,15 +6773,75 @@
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
+				"postcss": {
+					"version": "7.0.35",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+					"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							},
+							"dependencies": {
+								"supports-color": {
+									"version": "5.5.0",
+									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+									"dev": true,
+									"requires": {
+										"has-flag": "^3.0.0"
+									}
+								}
+							}
+						},
+						"color-convert": {
+							"version": "1.9.3",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+							"dev": true,
+							"requires": {
+								"color-name": "1.1.3"
+							}
+						},
+						"color-name": {
+							"version": "1.1.3",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+							"dev": true
+						}
+					}
+				},
 				"postcss-selector-parser": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+					"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
 						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
+						"uniq": "^1.0.1",
+						"util-deprecate": "^1.0.2"
 					}
 				},
 				"quick-lru": {
@@ -3528,11 +6894,40 @@
 						"strip-indent": "^3.0.0"
 					}
 				},
+				"regexp.prototype.flags": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+					"integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"resolve": {
+					"version": "2.0.0-next.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+					"integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.2.0",
+						"path-parse": "^1.0.6"
+					}
+				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				},
 				"shebang-command": {
 					"version": "1.2.0",
@@ -3549,15 +6944,80 @@
 					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
+				"side-channel": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"get-intrinsic": "^1.0.2",
+						"object-inspect": "^1.9.0"
+					}
+				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"emoji-regex": {
+							"version": "8.0.0",
+							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+							"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+							"dev": true
+						}
+					}
+				},
+				"string.prototype.matchall": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
+					"integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2",
+						"has-symbols": "^1.0.1",
+						"internal-slot": "^1.0.3",
+						"regexp.prototype.flags": "^1.3.1",
+						"side-channel": "^1.0.4"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
 					}
 				},
 				"strip-bom": {
@@ -3579,59 +7039,122 @@
 					}
 				},
 				"stylelint": {
-					"version": "13.6.1",
-					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.1.tgz",
-					"integrity": "sha512-XyvKyNE7eyrqkuZ85Citd/Uv3ljGiuYHC6UiztTR6sWS9rza8j3UeQv/eGcQS9NZz/imiC4GKdk1EVL3wst5vw==",
+					"version": "13.12.0",
+					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+					"integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
 					"dev": true,
 					"requires": {
-						"@stylelint/postcss-css-in-js": "^0.37.1",
-						"@stylelint/postcss-markdown": "^0.36.1",
-						"autoprefixer": "^9.8.0",
+						"@stylelint/postcss-css-in-js": "^0.37.2",
+						"@stylelint/postcss-markdown": "^0.36.2",
+						"autoprefixer": "^9.8.6",
 						"balanced-match": "^1.0.0",
 						"chalk": "^4.1.0",
-						"cosmiconfig": "^6.0.0",
-						"debug": "^4.1.1",
+						"cosmiconfig": "^7.0.0",
+						"debug": "^4.3.1",
 						"execall": "^2.0.0",
-						"file-entry-cache": "^5.0.1",
+						"fast-glob": "^3.2.5",
+						"fastest-levenshtein": "^1.0.12",
+						"file-entry-cache": "^6.0.1",
 						"get-stdin": "^8.0.0",
 						"global-modules": "^2.0.0",
-						"globby": "^11.0.1",
+						"globby": "^11.0.2",
 						"globjoin": "^0.1.4",
 						"html-tags": "^3.1.0",
 						"ignore": "^5.1.8",
 						"import-lazy": "^4.0.0",
 						"imurmurhash": "^0.1.4",
-						"known-css-properties": "^0.19.0",
-						"leven": "^3.1.0",
-						"lodash": "^4.17.15",
+						"known-css-properties": "^0.21.0",
+						"lodash": "^4.17.21",
 						"log-symbols": "^4.0.0",
 						"mathml-tag-names": "^2.1.3",
-						"meow": "^7.0.1",
+						"meow": "^9.0.0",
 						"micromatch": "^4.0.2",
 						"normalize-selector": "^0.2.0",
-						"postcss": "^7.0.32",
+						"postcss": "^7.0.35",
 						"postcss-html": "^0.36.0",
 						"postcss-less": "^3.1.4",
 						"postcss-media-query-parser": "^0.2.3",
-						"postcss-reporter": "^6.0.1",
 						"postcss-resolve-nested-selector": "^0.1.1",
 						"postcss-safe-parser": "^4.0.2",
 						"postcss-sass": "^0.4.4",
 						"postcss-scss": "^2.1.1",
-						"postcss-selector-parser": "^6.0.2",
+						"postcss-selector-parser": "^6.0.4",
 						"postcss-syntax": "^0.36.2",
 						"postcss-value-parser": "^4.1.0",
 						"resolve-from": "^5.0.0",
 						"slash": "^3.0.0",
 						"specificity": "^0.4.1",
-						"string-width": "^4.2.0",
+						"string-width": "^4.2.2",
 						"strip-ansi": "^6.0.0",
 						"style-search": "^0.1.0",
 						"sugarss": "^2.0.0",
 						"svg-tags": "^1.0.0",
-						"table": "^5.4.6",
-						"v8-compile-cache": "^2.1.1",
+						"table": "^6.0.7",
+						"v8-compile-cache": "^2.2.0",
 						"write-file-atomic": "^3.0.3"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.3.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+							"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+							"dev": true,
+							"requires": {
+								"ms": "2.1.2"
+							}
+						},
+						"ignore": {
+							"version": "5.1.8",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+							"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+							"dev": true
+						},
+						"v8-compile-cache": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+							"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+							"dev": true
+						}
+					}
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"table": {
+					"version": "6.0.9",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
+					"integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^8.0.1",
+						"is-boolean-object": "^1.1.0",
+						"is-number-object": "^1.0.4",
+						"is-string": "^1.0.5",
+						"lodash.clonedeep": "^4.5.0",
+						"lodash.flatten": "^4.4.0",
+						"lodash.truncate": "^4.4.2",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "8.0.5",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.5.tgz",
+							"integrity": "sha512-RkiLa/AeJx7+9OvniQ/qeWu0w74A8DiPPBclQ6ji3ZQkv5KamO+QGpqmi7O4JIw3rHGUXZ6CoP9tsAkn3gyazg==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"json-schema-traverse": "^1.0.0",
+								"require-from-string": "^2.0.2",
+								"uri-js": "^4.2.2"
+							}
+						}
 					}
 				},
 				"trim-newlines": {
@@ -3641,9 +7164,9 @@
 					"dev": true
 				},
 				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				},
 				"which": {
@@ -3662,21 +7185,28 @@
 					"dev": true
 				},
 				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
+					"version": "20.2.7",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+					"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+					"dev": true
 				}
 			}
 		},
+		"@wordpress/stylelint-config": {
+			"version": "19.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.0.2.tgz",
+			"integrity": "sha512-7tr2NL9VMqLjeZsEvjDoy7b0tm6KrVswZvxr5sJkgaJn4rOpI88SgKV3jh2qCZj4JTr8lfArzMS6dH9Ee2M0xw==",
+			"dev": true,
+			"requires": {
+				"stylelint-config-recommended": "^3.0.0",
+				"stylelint-config-recommended-scss": "^4.2.0",
+				"stylelint-scss": "^3.17.2"
+			}
+		},
 		"@wordpress/warning": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.2.0.tgz",
-			"integrity": "sha512-Q3WqbXHaoEuGddpFvVEmG9Xwpr5QMhi/NT+Q1td6J414fyNhafkmwGVd3roJB7/2y+ek2UDDegc32B8lkyW19A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.4.1.tgz",
+			"integrity": "sha512-Egpk1Tv4L0jVRUob0HF6iy4PLDDxN/0ALHHPzCkK2TXI9K5LurstbQV2KnM5/Q2cHc1J70n09Fd3P1E3DiCxEA==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -3692,26 +7222,10 @@
 			"dev": true
 		},
 		"abab": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-			"integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
 		},
 		"acorn": {
 			"version": "7.3.1",
@@ -3720,21 +7234,13 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+			"integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
-				}
+				"acorn": "^7.1.1",
+				"acorn-walk": "^7.1.1"
 			}
 		},
 		"acorn-jsx": {
@@ -3744,9 +7250,9 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -3756,9 +7262,9 @@
 			"dev": true
 		},
 		"aggregate-error": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
 			"dev": true,
 			"requires": {
 				"clean-stack": "^2.0.0",
@@ -3814,12 +7320,6 @@
 			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
 			"dev": true
 		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
-		},
 		"ansi-colors": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -3848,9 +7348,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -3862,16 +7362,6 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			}
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -3910,12 +7400,6 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
 		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
-		},
 		"array-filter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
@@ -3926,12 +7410,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-includes": {
@@ -3977,13 +7455,100 @@
 			}
 		},
 		"array.prototype.flat": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+			"integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"array.prototype.flatmap": {
@@ -4025,9 +7590,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
@@ -4099,18 +7664,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"async-foreach": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-			"dev": true
-		},
-		"async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4145,9 +7698,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
 		"axe-core": {
@@ -4177,92 +7730,33 @@
 			}
 		},
 		"babel-jest": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
-			"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+			"integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/babel__core": "^7.1.7",
 				"babel-plugin-istanbul": "^6.0.0",
-				"babel-preset-jest": "^25.5.0",
-				"chalk": "^3.0.0",
+				"babel-preset-jest": "^26.6.2",
+				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"slash": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"babel-loader": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
-			"integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
+			"integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^2.1.0",
+				"find-cache-dir": "^3.3.1",
 				"loader-utils": "^1.4.0",
-				"mkdirp": "^0.5.3",
-				"pify": "^4.0.1",
+				"make-dir": "^3.1.0",
 				"schema-utils": "^2.6.5"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -4281,17 +7775,6 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
-					}
-				},
-				"schema-utils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"ajv": "^6.12.2",
-						"ajv-keywords": "^3.4.1"
 					}
 				}
 			}
@@ -4319,20 +7802,59 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
-			"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+			"integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.3.3",
 				"@babel/types": "^7.3.3",
+				"@types/babel__core": "^7.0.0",
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
+		"babel-plugin-polyfill-corejs2": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz",
+			"integrity": "sha512-DO95wD4g0A8KRaHKi0D51NdGXzvpqVLnLu5BTvDlpqUEpTmeEtypgC1xqesORaWmiUOQI14UHKlzNd9iZ2G3ZA==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.0",
+				"@babel/helper-define-polyfill-provider": "^0.1.5",
+				"semver": "^6.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"babel-plugin-polyfill-corejs3": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz",
+			"integrity": "sha512-u+gbS9bbPhZWEeyy1oR/YaaSpod/KDT07arZHb80aTpl8H5ZBq+uN1nN9/xtX7jQyfLdPfoqI4Rue/MQSWJquw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.1.5",
+				"core-js-compat": "^3.8.1"
+			}
+		},
+		"babel-plugin-polyfill-regenerator": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz",
+			"integrity": "sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.1.5"
+			}
+		},
 		"babel-preset-current-node-syntax": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-			"integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -4345,17 +7867,18 @@
 				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
-			"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+			"integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^25.5.0",
-				"babel-preset-current-node-syntax": "^0.1.2"
+				"babel-plugin-jest-hoist": "^26.6.2",
+				"babel-preset-current-node-syntax": "^1.0.0"
 			}
 		},
 		"bail": {
@@ -4426,9 +7949,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -4440,18 +7963,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bfj": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
-			"integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
-			"dev": true,
-			"requires": {
-				"bluebird": "^3.5.5",
-				"check-types": "^8.0.3",
-				"hoopy": "^0.1.4",
-				"tryer": "^1.0.1"
-			}
-		},
 		"big.js": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -4459,11 +7970,10 @@
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-			"dev": true,
-			"optional": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -4476,9 +7986,9 @@
 			}
 		},
 		"bl": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.5.0",
@@ -4486,16 +7996,6 @@
 				"readable-stream": "^3.4.0"
 			},
 			"dependencies": {
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
 				"readable-stream": {
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -4509,15 +8009,6 @@
 				}
 			}
 		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
-		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4525,9 +8016,9 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-			"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 			"dev": true
 		},
 		"body": {
@@ -4540,71 +8031,6 @@
 				"error": "^7.0.0",
 				"raw-body": "~1.1.0",
 				"safe-json-parse": "~1.0.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-					"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-					"dev": true
-				},
-				"raw-body": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-					"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-					"dev": true,
-					"requires": {
-						"bytes": "1",
-						"string_decoder": "0.10"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
 			}
 		},
 		"boolbase": {
@@ -4664,23 +8090,6 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
 		},
-		"browser-resolve": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				}
-			}
-		},
 		"browserify-aes": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -4719,21 +8128,13 @@
 			}
 		},
 		"browserify-rsa": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+			"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
+				"bn.js": "^5.0.0",
 				"randombytes": "^2.0.1"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-					"dev": true
-				}
 			}
 		},
 		"browserify-sign": {
@@ -4803,14 +8204,13 @@
 			}
 		},
 		"buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"buffer-crc32": {
@@ -4838,32 +8238,66 @@
 			"dev": true
 		},
 		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+			"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
 			"dev": true
 		},
 		"cacache": {
-			"version": "12.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-			"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+			"version": "15.0.6",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.6.tgz",
+			"integrity": "sha512-g1WYDMct/jzW+JdWEyjaX2zoBkZ6ZT9VpOyp2I/VMtDsNLffNat3kqPFfi1eDRSK9/SuKGyORDHcQMcPF8sQ/w==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.5",
-				"chownr": "^1.1.1",
-				"figgy-pudding": "^3.5.1",
+				"@npmcli/move-file": "^1.0.1",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
 				"glob": "^7.1.4",
-				"graceful-fs": "^4.1.15",
-				"infer-owner": "^1.0.3",
-				"lru-cache": "^5.1.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^6.0.0",
+				"minipass": "^3.1.1",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.2",
+				"mkdirp": "^1.0.3",
+				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.3",
-				"ssri": "^6.0.1",
-				"unique-filename": "^1.1.1",
-				"y18n": "^4.0.0"
+				"rimraf": "^3.0.2",
+				"ssri": "^8.0.1",
+				"tar": "^6.0.2",
+				"unique-filename": "^1.1.1"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"cache-base": {
@@ -4881,6 +8315,16 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
+			}
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"call-me-maybe": {
@@ -5025,6 +8469,12 @@
 				}
 			}
 		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true
+		},
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -5050,114 +8500,248 @@
 			"dev": true
 		},
 		"check-node-version": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
-			"integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.1.0.tgz",
+			"integrity": "sha512-TSXGsyfW5/xY2QseuJn8/hleO2AU7HxVCdkc900jp1vcfzF840GkjvRT7CHl8sRtWn23n3X3k0cwH9RXeRwhfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.0",
+				"chalk": "^3.0.0",
 				"map-values": "^1.0.1",
 				"minimist": "^1.2.0",
 				"object-filter": "^1.0.2",
-				"object.assign": "^4.0.4",
 				"run-parallel": "^1.1.4",
-				"semver": "^5.0.3"
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"color-convert": "^2.0.1"
 					}
 				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
 				}
 			}
 		},
-		"check-types": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
-			"integrity": "sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==",
-			"dev": true
-		},
 		"cheerio": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+			"version": "1.0.0-rc.5",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
+			"integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
 			"dev": true,
 			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"cheerio-select-tmp": "^0.1.0",
+				"dom-serializer": "~1.2.0",
+				"domhandler": "^4.0.0",
+				"entities": "~2.1.0",
+				"htmlparser2": "^6.0.0",
+				"parse5": "^6.0.0",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0"
 			},
 			"dependencies": {
-				"css-select": {
+				"dom-serializer": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+					"integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
 					"dev": true,
 					"requires": {
-						"boolbase": "~1.0.0",
-						"css-what": "2.1",
-						"domutils": "1.5.1",
-						"nth-check": "~1.0.1"
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.0.0",
+						"entities": "^2.0.0"
 					}
 				},
-				"css-what": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-					"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+				"domelementtype": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
 					"dev": true
 				},
-				"dom-serializer": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+				"domhandler": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+					"integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
 					"dev": true,
 					"requires": {
-						"domelementtype": "^1.3.0",
-						"entities": "^1.1.1"
+						"domelementtype": "^2.2.0"
 					}
 				},
 				"domutils": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+					"integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
 					"dev": true,
 					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
+						"dom-serializer": "^1.0.1",
+						"domelementtype": "^2.2.0",
+						"domhandler": "^4.1.0"
+					}
+				},
+				"entities": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+					"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+					"dev": true
+				},
+				"htmlparser2": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.1.tgz",
+					"integrity": "sha512-GDKPd+vk4jvSuvCbyuzx/unmXkk090Azec7LovXP8as1Hn8q9p3hbjmDGbUqqhknw0ajwit6LiiWqfiTUPMK7w==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.0.0",
+						"domutils": "^2.4.4",
+						"entities": "^2.0.0"
+					}
+				}
+			}
+		},
+		"cheerio-select-tmp": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.1.tgz",
+			"integrity": "sha512-YYs5JvbpU19VYJyj+F7oYrIE2BOll1/hRU7rEy/5+v9BzkSo3bK81iAeeQEMI92vRIxz677m72UmJUiVwwgjfQ==",
+			"dev": true,
+			"requires": {
+				"css-select": "^3.1.2",
+				"css-what": "^4.0.0",
+				"domelementtype": "^2.1.0",
+				"domhandler": "^4.0.0",
+				"domutils": "^2.4.4"
+			},
+			"dependencies": {
+				"css-select": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+					"integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0",
+						"css-what": "^4.0.0",
+						"domhandler": "^4.0.0",
+						"domutils": "^2.4.3",
+						"nth-check": "^2.0.0"
+					}
+				},
+				"css-what": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+					"integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+					"dev": true
+				},
+				"dom-serializer": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+					"integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.0.0",
+						"entities": "^2.0.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
+					"integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.2.0"
+					}
+				},
+				"domutils": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.1.tgz",
+					"integrity": "sha512-hO1XwHMGAthA/1KL7c83oip/6UWo3FlUNIuWiWKltoiQ5oCOiqths8KknvY2jpOohUoUgnwa/+Rm7UpwpSbY/Q==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "^1.0.1",
+						"domelementtype": "^2.2.0",
+						"domhandler": "^4.1.0"
+					}
+				},
+				"entities": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+					"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+					"dev": true
+				},
+				"nth-check": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+					"integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0"
 					}
 				}
 			}
 		},
 		"chokidar": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-			"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+			"integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
+				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.4.0"
+				"readdirp": "~3.5.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -5165,7 +8749,6 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
@@ -5175,7 +8758,6 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
@@ -5184,15 +8766,13 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-number": "^7.0.0"
 					}
@@ -5234,6 +8814,12 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cjs-module-lexer": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+			"integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
 			"dev": true
 		},
 		"class-utils": {
@@ -5314,9 +8900,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -5495,31 +9081,16 @@
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
 			"dev": true
 		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
-		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
 			"dev": true
 		},
 		"continuable-cache": {
@@ -5536,18 +9107,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-			"dev": true
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -5570,21 +9129,58 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+			"integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
-			"integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.0.tgz",
+			"integrity": "sha512-9yVewub2MXNYyGvuLnMHcN1k9RkvB7/ofktpeKTIaASyB88YYqGzUnu0ywMMhJrDHOMiTjSHWGzR+i7Wb9Z1kQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.5",
+				"browserslist": "^4.16.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
+				"browserslist": {
+					"version": "4.16.3",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+					"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001181",
+						"colorette": "^1.2.1",
+						"electron-to-chromium": "^1.3.649",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.70"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001207",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+					"integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.709",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.709.tgz",
+					"integrity": "sha512-LolItk2/ikSGQ7SN8UkuKVNMBZp3RG7Itgaxj1npsHRzQobj9JjMneZOZfLhtwlYBe5fCJ75k+cVCiDFUs23oA==",
+					"dev": true
+				},
+				"escalade": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.71",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+					"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+					"dev": true
+				},
 				"semver": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -5655,9 +9251,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
@@ -5740,12 +9336,6 @@
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -5770,17 +9360,6 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
-					}
-				},
-				"schema-utils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"ajv": "^6.12.2",
-						"ajv-keywords": "^3.4.1"
 					}
 				},
 				"semver": {
@@ -5820,9 +9399,9 @@
 			}
 		},
 		"css-what": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-			"integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+			"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
 			"dev": true
 		},
 		"cssesc": {
@@ -5832,28 +9411,28 @@
 			"dev": true
 		},
 		"csso": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
-			"integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
 			"dev": true,
 			"requires": {
-				"css-tree": "1.0.0-alpha.39"
+				"css-tree": "^1.1.2"
 			},
 			"dependencies": {
 				"css-tree": {
-					"version": "1.0.0-alpha.39",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
-					"integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+					"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
 					"dev": true,
 					"requires": {
-						"mdn-data": "2.0.6",
+						"mdn-data": "2.0.14",
 						"source-map": "^0.6.1"
 					}
 				},
 				"mdn-data": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
-					"integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==",
+					"version": "2.0.14",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+					"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
 					"dev": true
 				}
 			}
@@ -5880,6 +9459,12 @@
 					"dev": true
 				}
 			}
+		},
+		"csstype": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+			"integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
+			"dev": true
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -5932,14 +9517,14 @@
 			}
 		},
 		"data-urls": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+			"integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "^2.0.3",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^8.0.0"
 			}
 		},
 		"debug": {
@@ -5974,6 +9559,12 @@
 					"dev": true
 				}
 			}
+		},
+		"decimal.js": {
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -6093,18 +9684,6 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
-		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -6114,12 +9693,6 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
 			}
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
 		},
 		"detect-file": {
 			"version": "1.0.0",
@@ -6133,10 +9706,16 @@
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
+		"devtools-protocol": {
+			"version": "0.0.818844",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+			"dev": true
+		},
 		"diff-sequences": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+			"integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
 			"dev": true
 		},
 		"diffie-hellman": {
@@ -6151,9 +9730,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
@@ -6219,12 +9798,20 @@
 			"dev": true
 		},
 		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+			"integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "^5.0.0"
+			},
+			"dependencies": {
+				"webidl-conversions": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+					"dev": true
+				}
 			}
 		},
 		"domhandler": {
@@ -6283,18 +9870,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"ejs": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-			"dev": true
-		},
 		"electron-to-chromium": {
 			"version": "1.3.499",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.499.tgz",
@@ -6302,27 +9877,33 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
 				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
+		},
+		"emittery": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -6336,12 +9917,6 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-			"dev": true
-		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -6352,9 +9927,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-			"integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+			"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -6420,49 +9995,246 @@
 			}
 		},
 		"enzyme-adapter-react-16": {
-			"version": "1.15.3",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.3.tgz",
-			"integrity": "sha512-98rqNI4n9HZslWIPuuwy4hK1bxRuMy+XX0CU1dS8iUqcgisTxeBaap6oPp2r4MWC8OphCbbqAT8EU/xHz3zIaQ==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
+			"integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "^1.13.1",
+				"enzyme-adapter-utils": "^1.14.0",
 				"enzyme-shallow-equal": "^1.0.4",
 				"has": "^1.0.3",
-				"object.assign": "^4.1.0",
-				"object.values": "^1.1.1",
+				"object.assign": "^4.1.2",
+				"object.values": "^1.1.2",
 				"prop-types": "^15.7.2",
 				"react-is": "^16.13.1",
 				"react-test-renderer": "^16.0.0-0",
 				"semver": "^5.7.0"
 			},
 			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"object.values": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+					"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2",
+						"has": "^1.0.3"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
 				}
 			}
 		},
 		"enzyme-adapter-utils": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.1.tgz",
-			"integrity": "sha512-5A9MXXgmh/Tkvee3bL/9RCAAgleHqFnsurTYCbymecO4ohvtNO5zqIhHxV370t7nJAwaCfkgtffarKpC0GPt0g==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
+			"integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
 			"dev": true,
 			"requires": {
 				"airbnb-prop-types": "^2.16.0",
-				"function.prototype.name": "^1.1.2",
-				"object.assign": "^4.1.0",
-				"object.fromentries": "^2.0.2",
+				"function.prototype.name": "^1.1.3",
+				"has": "^1.0.3",
+				"object.assign": "^4.1.2",
+				"object.fromentries": "^2.0.3",
 				"prop-types": "^15.7.2",
 				"semver": "^5.7.1"
 			},
 			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"object.fromentries": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
+					"integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2",
+						"has": "^1.0.3"
+					}
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
 				}
 			}
 		},
@@ -6477,19 +10249,20 @@
 			}
 		},
 		"enzyme-to-json": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.5.0.tgz",
-			"integrity": "sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.6.1.tgz",
+			"integrity": "sha512-15tXuONeq5ORoZjV/bUo2gbtZrN2IH+Z6DvL35QmZyKHgbY1ahn6wcnLd9Xv9OjiwbAXiiP8MRZwbZrCv1wYNg==",
 			"dev": true,
 			"requires": {
+				"@types/cheerio": "^0.22.22",
 				"lodash": "^4.17.15",
 				"react-is": "^16.12.0"
 			}
 		},
 		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
@@ -6632,12 +10405,6 @@
 			"integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
 			"dev": true
 		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -6645,18 +10412,24 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+			"integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
-				"estraverse": "^4.2.0",
+				"estraverse": "^5.2.0",
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				},
 				"levn": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -6755,51 +10528,217 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+			"dev": true
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+			"integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^6.0.0"
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
 			},
 			"dependencies": {
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
 		},
-		"eslint-plugin-jest": {
-			"version": "23.20.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
-			"integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
+		"eslint-module-utils": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^2.5.0"
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.1",
+				"array.prototype.flat": "^1.2.3",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.4",
+				"eslint-module-utils": "^2.6.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.1",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.17.0",
+				"tsconfig-paths": "^3.9.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-jest": {
+			"version": "24.3.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.4.tgz",
+			"integrity": "sha512-3n5oY1+fictanuFkTWPwSlehugBTAgwLnYLFsCllzE3Pl1BwywHl5fL0HFxmMjoQY8xhUDk8uAWc3S4JOHGh3A==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^4.0.1"
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "26.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-26.0.2.tgz",
-			"integrity": "sha512-KtZjqtM3Z8x84vQBFKGUyBbZRGXYHVWSJ2XyYSUTc8KhfFrvzQ/GXPp6f1M1/YCNzP3ImD5RuDNcr+OVvIZcBA==",
+			"version": "30.7.13",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.7.13.tgz",
+			"integrity": "sha512-YM4WIsmurrp0rHX6XiXQppqKB8Ne5ATiZLJe2+/fkp9l9ExXFr43BbAbjZaVrpCT+tuPYOZ8k1MICARHnURUNQ==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "^0.7.4",
-				"debug": "^4.1.1",
-				"jsdoctypeparser": "^6.1.0",
-				"lodash": "^4.17.15",
+				"comment-parser": "^0.7.6",
+				"debug": "^4.3.1",
+				"jsdoctypeparser": "^9.0.0",
+				"lodash": "^4.17.20",
 				"regextras": "^0.7.1",
-				"semver": "^6.3.0",
+				"semver": "^7.3.4",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				}
 			}
 		},
@@ -6908,9 +10847,9 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-			"integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
+			"integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -7032,12 +10971,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-			"dev": true
-		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -7049,9 +10982,9 @@
 			}
 		},
 		"events": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true
 		},
 		"evp_bytestokey": {
@@ -7065,9 +10998,9 @@
 			}
 		},
 		"exec-sh": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
-			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
+			"integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==",
 			"dev": true
 		},
 		"execa": {
@@ -7217,26 +11150,25 @@
 			}
 		},
 		"expect": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
-			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+			"integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
+				"@jest/types": "^26.6.2",
 				"ansi-styles": "^4.0.0",
-				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-regex-util": "^25.2.6"
+				"jest-get-type": "^26.3.0",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-regex-util": "^26.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -7262,67 +11194,6 @@
 			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
 			"dev": true
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
-			}
 		},
 		"ext": {
 			"version": "1.4.0",
@@ -7544,10 +11415,16 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fastest-levenshtein": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+			"integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+			"dev": true
+		},
 		"fastq": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+			"integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -7605,18 +11482,53 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
+		"file-loader": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+			"integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"schema-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+					"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.6",
+						"ajv": "^6.12.5",
+						"ajv-keywords": "^3.5.2"
+					}
+				}
+			}
+		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true,
 			"optional": true
-		},
-		"filesize": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-			"dev": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -7641,47 +11553,75 @@
 				}
 			}
 		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"find-cache-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^2.0.0",
-				"pkg-dir": "^3.0.0"
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				}
 			}
 		},
 		"find-file-up": {
@@ -7710,40 +11650,20 @@
 			}
 		},
 		"find-process": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
-			"integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.4.tgz",
+			"integrity": "sha512-rRSuT1LE4b+BFK588D2V8/VG9liW0Ark1XJgroxZXI0LtwmQJOb490DvDYvbm+Hek9ETFzTutGfJ90gumITPhQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"commander": "^2.11.0",
-				"debug": "^2.6.8"
+				"chalk": "^4.0.0",
+				"commander": "^5.1.0",
+				"debug": "^4.1.1"
 			},
 			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+				"commander": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
 					"dev": true
 				}
 			}
@@ -7903,12 +11823,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-			"dev": true
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7917,12 +11831,6 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -7994,23 +11902,11 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"dev": true,
 			"optional": true
-		},
-		"fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -8019,14 +11915,101 @@
 			"dev": true
 		},
 		"function.prototype.name": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-			"integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.4.tgz",
+			"integrity": "sha512-iqy1pIotY/RmhdFZygSSlW0wko2yxkSCKqsuv4pr8QESohpYyG/Z7B/XXvPRKTJS//960rgguE5mSRUsDdaJrQ==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"functions-have-names": "^1.2.0"
+				"es-abstract": "^1.18.0-next.2",
+				"functions-have-names": "^1.2.2"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"functional-red-black-tree": {
@@ -8036,72 +12019,10 @@
 			"dev": true
 		},
 		"functions-have-names": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-			"integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+			"integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
 			"dev": true
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
-		"gaze": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-			"dev": true,
-			"requires": {
-				"globule": "^1.0.0"
-			}
 		},
 		"generate-function": {
 			"version": "2.3.1",
@@ -8132,6 +12053,17 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -8316,13 +12248,12 @@
 			"optional": true
 		},
 		"gzip-size": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+			"integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
 			"dev": true,
 			"requires": {
-				"duplexer": "^0.1.1",
-				"pify": "^4.0.1"
+				"duplexer": "^0.1.2"
 			}
 		},
 		"har-schema": {
@@ -8373,6 +12304,12 @@
 				}
 			}
 		},
+		"has-bigints": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"dev": true
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -8383,12 +12320,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
 		"has-value": {
@@ -8483,12 +12414,6 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
-		"hoopy": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
-			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
-			"dev": true
-		},
 		"hosted-git-info": {
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -8496,21 +12421,22 @@
 			"dev": true
 		},
 		"html-element-map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.2.0.tgz",
-			"integrity": "sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.0.tgz",
+			"integrity": "sha512-AqCt/m9YaiMwaaAyOPdq4Ga0cM+jdDWWGueUMkdROZcTeClaGpN0AQeyGchZhTegQoABmc6+IqH7oCR/8vhQYg==",
 			"dev": true,
 			"requires": {
-				"array-filter": "^1.0.0"
+				"array-filter": "^1.0.0",
+				"call-bind": "^1.0.2"
 			}
 		},
 		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "^1.0.5"
 			}
 		},
 		"html-escaper": {
@@ -8552,31 +12478,10 @@
 				}
 			}
 		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				}
-			}
-		},
 		"http-parser-js": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-			"integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+			"integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
 			"dev": true
 		},
 		"http-signature": {
@@ -8631,9 +12536,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
 			"dev": true
 		},
 		"iferr": {
@@ -8770,12 +12675,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
-		},
-		"in-publish": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-			"integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
 			"dev": true
 		},
 		"indent-string": {
@@ -8918,27 +12817,6 @@
 			"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
 			"dev": true
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"ip-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-			"integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
-			"dev": true
-		},
-		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true
-		},
 		"irregular-plurals": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
@@ -8993,21 +12871,29 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
+		"is-bigint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"dev": true
+		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
-			"integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
-			"dev": true
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -9028,6 +12914,15 @@
 			"dev": true,
 			"requires": {
 				"ci-info": "^2.0.0"
+			}
+		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -9088,9 +12983,9 @@
 			"dev": true
 		},
 		"is-docker": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.0.tgz",
+			"integrity": "sha512-K4GwB4i/HzhAzwP/XSlspzRdFTI9N8OxJOyOU7Y5Rz+p+WBokXWVWblaJeBkggthmoSV0OoGTH5thJNvplpkvQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -9104,12 +12999,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-finite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -9157,6 +13046,12 @@
 				"jsonpointer": "^4.0.0",
 				"xtend": "^4.0.0"
 			}
+		},
+		"is-negative-zero": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"dev": true
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -9229,6 +13124,12 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true
+		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -9289,14 +13190,17 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
+		"is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true
+		},
 		"is-url-superb": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-3.0.0.tgz",
-			"integrity": "sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==",
-			"dev": true,
-			"requires": {
-				"url-regex": "^5.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+			"integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -9323,10 +13227,14 @@
 			"dev": true
 		},
 		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -9395,25 +13303,10 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -9443,105 +13336,54 @@
 			}
 		},
 		"jest": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
-			"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+			"integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^25.5.4",
+				"@jest/core": "^26.6.3",
 				"import-local": "^3.0.2",
-				"jest-cli": "^25.5.4"
+				"jest-cli": "^26.6.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"jest-cli": {
-					"version": "25.5.4",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
-					"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
+					"version": "26.6.3",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+					"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^25.5.4",
-						"@jest/test-result": "^25.5.0",
-						"@jest/types": "^25.5.0",
-						"chalk": "^3.0.0",
+						"@jest/core": "^26.6.3",
+						"@jest/test-result": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"chalk": "^4.0.0",
 						"exit": "^0.1.2",
 						"graceful-fs": "^4.2.4",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^25.5.4",
-						"jest-util": "^25.5.0",
-						"jest-validate": "^25.5.0",
+						"jest-config": "^26.6.3",
+						"jest-util": "^26.6.2",
+						"jest-validate": "^26.6.2",
 						"prompts": "^2.0.1",
-						"realpath-native": "^2.0.0",
-						"yargs": "^15.3.1"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
+						"yargs": "^15.4.1"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
-			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+			"integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"execa": "^3.2.0",
+				"@jest/types": "^26.6.2",
+				"execa": "^4.0.0",
 				"throat": "^5.0.0"
 			},
 			"dependencies": {
 				"execa": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -9551,7 +13393,6 @@
 						"merge-stream": "^2.0.0",
 						"npm-run-path": "^4.0.0",
 						"onetime": "^5.1.0",
-						"p-finally": "^2.0.0",
 						"signal-exit": "^3.0.2",
 						"strip-final-newline": "^2.0.0"
 					}
@@ -9588,92 +13429,33 @@
 					"requires": {
 						"mimic-fn": "^2.1.0"
 					}
-				},
-				"p-finally": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-					"dev": true
 				}
 			}
 		},
 		"jest-config": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
-			"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+			"integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^25.5.4",
-				"@jest/types": "^25.5.0",
-				"babel-jest": "^25.5.1",
-				"chalk": "^3.0.0",
+				"@jest/test-sequencer": "^26.6.3",
+				"@jest/types": "^26.6.2",
+				"babel-jest": "^26.6.3",
+				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-environment-jsdom": "^25.5.0",
-				"jest-environment-node": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"jest-jasmine2": "^25.5.4",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
+				"jest-environment-jsdom": "^26.6.2",
+				"jest-environment-node": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"jest-jasmine2": "^26.6.3",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^25.5.0",
-				"realpath-native": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-dev-server": {
@@ -9692,12 +13474,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -9733,9 +13514,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -9744,496 +13525,169 @@
 			}
 		},
 		"jest-diff": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+			"integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^3.0.0",
-				"diff-sequences": "^25.2.6",
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"chalk": "^4.0.0",
+				"diff-sequences": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-docblock": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
-			"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+			"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
-			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+			"integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.6",
-				"jest-util": "^25.5.0",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
+				"jest-util": "^26.6.2",
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
-			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+			"integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"jsdom": "^15.2.1"
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jsdom": "^16.4.0"
 			}
 		},
 		"jest-environment-node": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
-			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+			"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^25.5.0",
-				"@jest/fake-timers": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"jest-environment-puppeteer": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.4.0.tgz",
-			"integrity": "sha512-iV8S8+6qkdTM6OBR/M9gKywEk8GDSOe05hspCs5D8qKSwtmlUfdtHfB4cakdc68lC6YfK3AUsLirpfgodCHjzQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^3.0.0",
-				"cwd": "^0.10.0",
-				"jest-dev-server": "^4.4.0",
-				"merge-deep": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
 			}
 		},
 		"jest-get-type": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+			"integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
-			"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+			"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
+				"@jest/types": "^26.6.2",
 				"@types/graceful-fs": "^4.1.2",
+				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-serializer": "^25.5.0",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
+				"jest-regex-util": "^26.0.0",
+				"jest-serializer": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
-				"walker": "^1.0.7",
-				"which": "^2.0.2"
+				"walker": "^1.0.7"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
-			"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+			"integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/source-map": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
+				"@jest/environment": "^26.6.2",
+				"@jest/source-map": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^25.5.0",
+				"expect": "^26.6.2",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^25.5.0",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-runtime": "^25.5.4",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"pretty-format": "^25.5.0",
+				"jest-each": "^26.6.2",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-runtime": "^26.6.3",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"pretty-format": "^26.6.2",
 				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"jest-leak-detector": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
-			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+			"integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
-			"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+			"integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^3.0.0",
-				"jest-diff": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"pretty-format": "^25.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"chalk": "^4.0.0",
+				"jest-diff": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"pretty-format": "^26.6.2"
 			}
 		},
 		"jest-message-util": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
-			"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+			"integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/types": "^25.5.0",
-				"@types/stack-utils": "^1.0.1",
-				"chalk": "^3.0.0",
+				"@jest/types": "^26.6.2",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.2",
+				"pretty-format": "^26.6.2",
 				"slash": "^3.0.0",
-				"stack-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"stack-utils": "^2.0.2"
 			}
 		},
 		"jest-mock": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
-			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+			"integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0"
+				"@jest/types": "^26.6.2",
+				"@types/node": "*"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -10242,74 +13696,28 @@
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
 			"dev": true
 		},
-		"jest-puppeteer": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-4.4.0.tgz",
-			"integrity": "sha512-ZaiCTlPZ07B9HW0erAWNX6cyzBqbXMM7d2ugai4epBDKpKvRDpItlRQC6XjERoJELKZsPziFGS0OhhUvTvQAXA==",
-			"dev": true,
-			"requires": {
-				"expect-puppeteer": "^4.4.0",
-				"jest-environment-puppeteer": "^4.4.0"
-			}
-		},
 		"jest-regex-util": {
-			"version": "25.2.6",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
-			"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
-			"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+			"integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^3.0.0",
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-pnp-resolver": "^1.2.1",
+				"jest-pnp-resolver": "^1.2.2",
+				"jest-util": "^26.6.2",
 				"read-pkg-up": "^7.0.1",
-				"realpath-native": "^2.0.0",
-				"resolve": "^1.17.0",
+				"resolve": "^1.18.1",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -10319,12 +13727,6 @@
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
 				},
 				"locate-path": {
 					"version": "5.0.0",
@@ -10360,14 +13762,14 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -10408,537 +13810,209 @@
 						"type-fest": "^0.8.1"
 					}
 				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+				"resolve": {
+					"version": "1.20.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+					"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"is-core-module": "^2.2.0",
+						"path-parse": "^1.0.6"
 					}
 				}
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
-			"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+			"integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-snapshot": "^25.5.1"
+				"@jest/types": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-snapshot": "^26.6.2"
 			}
 		},
 		"jest-runner": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
-			"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+			"integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
+				"@jest/console": "^26.6.2",
+				"@jest/environment": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"emittery": "^0.7.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^25.5.4",
-				"jest-docblock": "^25.3.0",
-				"jest-haste-map": "^25.5.1",
-				"jest-jasmine2": "^25.5.4",
-				"jest-leak-detector": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-resolve": "^25.5.1",
-				"jest-runtime": "^25.5.4",
-				"jest-util": "^25.5.0",
-				"jest-worker": "^25.5.0",
+				"jest-config": "^26.6.3",
+				"jest-docblock": "^26.0.0",
+				"jest-haste-map": "^26.6.2",
+				"jest-leak-detector": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-resolve": "^26.6.2",
+				"jest-runtime": "^26.6.3",
+				"jest-util": "^26.6.2",
+				"jest-worker": "^26.6.2",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"jest-runtime": {
-			"version": "25.5.4",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
-			"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+			"integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^25.5.0",
-				"@jest/environment": "^25.5.0",
-				"@jest/globals": "^25.5.2",
-				"@jest/source-map": "^25.5.0",
-				"@jest/test-result": "^25.5.0",
-				"@jest/transform": "^25.5.1",
-				"@jest/types": "^25.5.0",
+				"@jest/console": "^26.6.2",
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/globals": "^26.6.2",
+				"@jest/source-map": "^26.6.2",
+				"@jest/test-result": "^26.6.2",
+				"@jest/transform": "^26.6.2",
+				"@jest/types": "^26.6.2",
 				"@types/yargs": "^15.0.0",
-				"chalk": "^3.0.0",
+				"chalk": "^4.0.0",
+				"cjs-module-lexer": "^0.6.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.4",
-				"jest-config": "^25.5.4",
-				"jest-haste-map": "^25.5.1",
-				"jest-message-util": "^25.5.0",
-				"jest-mock": "^25.5.0",
-				"jest-regex-util": "^25.2.6",
-				"jest-resolve": "^25.5.1",
-				"jest-snapshot": "^25.5.1",
-				"jest-util": "^25.5.0",
-				"jest-validate": "^25.5.0",
-				"realpath-native": "^2.0.0",
+				"jest-config": "^26.6.3",
+				"jest-haste-map": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-mock": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-resolve": "^26.6.2",
+				"jest-snapshot": "^26.6.2",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
-				"yargs": "^15.3.1"
+				"yargs": "^15.4.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"strip-bom": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
 					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
-			"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+			"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"graceful-fs": "^4.2.4"
 			}
 		},
 		"jest-snapshot": {
-			"version": "25.5.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
-			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+			"integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^25.5.0",
-				"@types/prettier": "^1.19.0",
-				"chalk": "^3.0.0",
-				"expect": "^25.5.0",
+				"@jest/types": "^26.6.2",
+				"@types/babel__traverse": "^7.0.4",
+				"@types/prettier": "^2.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^26.6.2",
 				"graceful-fs": "^4.2.4",
-				"jest-diff": "^25.5.0",
-				"jest-get-type": "^25.2.6",
-				"jest-matcher-utils": "^25.5.0",
-				"jest-message-util": "^25.5.0",
-				"jest-resolve": "^25.5.1",
-				"make-dir": "^3.0.0",
+				"jest-diff": "^26.6.2",
+				"jest-get-type": "^26.3.0",
+				"jest-haste-map": "^26.6.2",
+				"jest-matcher-utils": "^26.6.2",
+				"jest-message-util": "^26.6.2",
+				"jest-resolve": "^26.6.2",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^25.5.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"pretty-format": "^26.6.2",
+				"semver": "^7.3.2"
 			}
 		},
 		"jest-util": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
-			"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"chalk": "^3.0.0",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"is-ci": "^2.0.0",
-				"make-dir": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
+				"micromatch": "^4.0.2"
 			}
 		},
 		"jest-validate": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
-			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+			"integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^3.0.0",
-				"jest-get-type": "^25.2.6",
+				"@jest/types": "^26.6.2",
+				"camelcase": "^6.0.0",
+				"chalk": "^4.0.0",
+				"jest-get-type": "^26.3.0",
 				"leven": "^3.1.0",
-				"pretty-format": "^25.5.0"
+				"pretty-format": "^26.6.2"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
 				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+					"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 					"dev": true
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
 		"jest-watcher": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
-			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+			"integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^25.5.0",
-				"@jest/types": "^25.5.0",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
-				"chalk": "^3.0.0",
-				"jest-util": "^25.5.0",
-				"string-length": "^3.1.0"
+				"chalk": "^4.0.0",
+				"jest-util": "^26.6.2",
+				"string-length": "^4.0.1"
 			},
 			"dependencies": {
 				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+					"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.11.0"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
+						"type-fest": "^0.21.3"
 					}
 				},
 				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
 		},
 		"jest-worker": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
-			"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
 			"dev": true,
 			"requires": {
+				"@types/node": "*",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^7.0.0"
 			},
@@ -10950,21 +14024,15 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
 				}
 			}
-		},
-		"js-base64": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
-			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -10989,49 +14057,49 @@
 			"dev": true
 		},
 		"jsdoctypeparser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
-			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+			"integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
 			"dev": true
 		},
 		"jsdom": {
-			"version": "15.2.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+			"version": "16.5.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
+			"integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^7.1.0",
-				"acorn-globals": "^4.3.2",
-				"array-equal": "^1.0.0",
-				"cssom": "^0.4.1",
-				"cssstyle": "^2.0.0",
-				"data-urls": "^1.1.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.11.1",
-				"html-encoding-sniffer": "^1.0.2",
+				"abab": "^2.0.5",
+				"acorn": "^8.1.0",
+				"acorn-globals": "^6.0.0",
+				"cssom": "^0.4.4",
+				"cssstyle": "^2.3.0",
+				"data-urls": "^2.0.0",
+				"decimal.js": "^10.2.1",
+				"domexception": "^2.0.1",
+				"escodegen": "^2.0.0",
+				"html-encoding-sniffer": "^2.0.1",
+				"is-potential-custom-element-name": "^1.0.0",
 				"nwsapi": "^2.2.0",
-				"parse5": "5.1.0",
-				"pn": "^1.1.0",
-				"request": "^2.88.0",
-				"request-promise-native": "^1.0.7",
-				"saxes": "^3.1.9",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^3.0.1",
-				"w3c-hr-time": "^1.0.1",
-				"w3c-xmlserializer": "^1.1.2",
-				"webidl-conversions": "^4.0.2",
+				"parse5": "6.0.1",
+				"request": "^2.88.2",
+				"request-promise-native": "^1.0.9",
+				"saxes": "^5.0.1",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.0.0",
+				"w3c-hr-time": "^1.0.2",
+				"w3c-xmlserializer": "^2.0.0",
+				"webidl-conversions": "^6.1.0",
 				"whatwg-encoding": "^1.0.5",
 				"whatwg-mimetype": "^2.3.0",
-				"whatwg-url": "^7.0.0",
-				"ws": "^7.0.0",
+				"whatwg-url": "^8.5.0",
+				"ws": "^7.4.4",
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"parse5": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+				"acorn": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+					"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
 					"dev": true
 				}
 			}
@@ -11046,6 +14114,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
 		"json-schema": {
@@ -11190,15 +14264,6 @@
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
 		},
-		"levenary": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-			"dev": true,
-			"requires": {
-				"leven": "^3.1.0"
-			}
-		},
 		"levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -11289,6 +14354,18 @@
 			"integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
 			"dev": true
 		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
+		},
 		"lodash.differencewith": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
@@ -11325,10 +14402,10 @@
 			"integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
 			"dev": true
 		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+		"lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -11351,15 +14428,6 @@
 						"supports-color": "^5.3.0"
 					}
 				}
-			}
-		},
-		"lolex": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.7.0"
 			}
 		},
 		"longest-streak": {
@@ -11388,28 +14456,27 @@
 			}
 		},
 		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"requires": {
-				"yallist": "^3.0.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 			"dev": true,
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
+				"semver": "^6.0.0"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -11578,6 +14645,71 @@
 				"unist-util-visit": "^1.1.0"
 			}
 		},
+		"mdast-util-from-markdown": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+			"integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^3.0.0",
+				"mdast-util-to-string": "^2.0.0",
+				"micromark": "~2.11.0",
+				"parse-entities": "^2.0.0",
+				"unist-util-stringify-position": "^2.0.0"
+			},
+			"dependencies": {
+				"parse-entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+					"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+					"dev": true,
+					"requires": {
+						"character-entities": "^1.0.0",
+						"character-entities-legacy": "^1.0.0",
+						"character-reference-invalid": "^1.0.0",
+						"is-alphanumerical": "^1.0.0",
+						"is-decimal": "^1.0.0",
+						"is-hexadecimal": "^1.0.0"
+					}
+				}
+			}
+		},
+		"mdast-util-to-markdown": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+			"integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^2.0.0",
+				"longest-streak": "^2.0.0",
+				"mdast-util-to-string": "^2.0.0",
+				"parse-entities": "^2.0.0",
+				"repeat-string": "^1.0.0",
+				"zwitch": "^1.0.0"
+			},
+			"dependencies": {
+				"parse-entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+					"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+					"dev": true,
+					"requires": {
+						"character-entities": "^1.0.0",
+						"character-entities-legacy": "^1.0.0",
+						"character-reference-invalid": "^1.0.0",
+						"is-alphanumerical": "^1.0.0",
+						"is-decimal": "^1.0.0",
+						"is-hexadecimal": "^1.0.0"
+					}
+				}
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+			"integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+			"dev": true
+		},
 		"mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -11588,12 +14720,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-			"dev": true
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
 		"memory-fs": {
@@ -11630,9 +14756,9 @@
 			"dev": true
 		},
 		"merge-deep": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+			"integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -11651,12 +14777,6 @@
 				}
 			}
 		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11669,11 +14789,31 @@
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
 		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
+		"micromark": {
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+			"integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.0.0",
+				"parse-entities": "^2.0.0"
+			},
+			"dependencies": {
+				"parse-entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+					"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+					"dev": true,
+					"requires": {
+						"character-entities": "^1.0.0",
+						"character-entities-legacy": "^1.0.0",
+						"character-reference-invalid": "^1.0.0",
+						"is-alphanumerical": "^1.0.0",
+						"is-decimal": "^1.0.0",
+						"is-hexadecimal": "^1.0.0"
+					}
+				}
+			}
 		},
 		"micromatch": {
 			"version": "4.0.2",
@@ -11731,32 +14871,32 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
 		},
 		"mime": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-			"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+			"integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"version": "2.1.30",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+			"integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.44.0"
+				"mime-db": "1.47.0"
 			}
 		},
 		"mimic-fn": {
@@ -11783,6 +14923,12 @@
 				"webpack-sources": "^1.1.0"
 			},
 			"dependencies": {
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -11801,6 +14947,27 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -11849,14 +15016,6 @@
 			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
 			}
 		},
 		"minipass-collect": {
@@ -11894,14 +15053,6 @@
 			"requires": {
 				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
-				}
 			}
 		},
 		"mississippi": {
@@ -12009,10 +15160,11 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -12040,31 +15192,16 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.19.5",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.5.tgz",
-			"integrity": "sha512-qoh1ZXXl0Kpn40tFhmgvffUAlbpRMcjLUagNVnT1JmliUIsB4tFabmCNhD97+tkf9FZ/SLhhYzNow0V3GitzDg==",
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
 				"moo": "^0.5.0",
 				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6",
-				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
+				"randexp": "0.4.6"
 			}
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -12084,42 +15221,11 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-gyp": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-			"dev": true,
-			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
-			}
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -12158,6 +15264,17 @@
 				"vm-browserify": "^1.0.1"
 			},
 			"dependencies": {
+				"buffer": {
+					"version": "4.9.2",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
+					}
+				},
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -12188,46 +15305,18 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
-			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
+			"integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"is-wsl": "^2.1.1",
-				"semver": "^6.3.0",
+				"is-wsl": "^2.2.0",
+				"semver": "^7.3.2",
 				"shellwords": "^0.1.1",
-				"which": "^1.3.1"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"is-docker": "^2.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true,
-					"optional": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				}
+				"uuid": "^8.3.0",
+				"which": "^2.0.2"
 			}
 		},
 		"node-releases": {
@@ -12235,285 +15324,6 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
 			"integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
 			"dev": true
-		},
-		"node-sass": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
-			"integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
-			"dev": true,
-			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash": "^4.17.15",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.13.2",
-				"node-gyp": "^3.8.0",
-				"npmlog": "^4.0.0",
-				"request": "^2.88.0",
-				"sass-graph": "2.2.5",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^2.0.0",
-						"map-obj": "^1.0.0"
-					}
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"get-stdin": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				},
-				"meow": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^2.0.0",
-						"decamelize": "^1.1.2",
-						"loud-rejection": "^1.0.0",
-						"map-obj": "^1.0.1",
-						"minimist": "^1.1.3",
-						"normalize-package-data": "^2.3.4",
-						"object-assign": "^4.0.1",
-						"read-pkg-up": "^1.0.1",
-						"redent": "^1.0.0",
-						"trim-newlines": "^1.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-type": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
-					}
-				},
-				"redent": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^2.1.0",
-						"strip-indent": "^1.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"strip-indent": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
-					"requires": {
-						"get-stdin": "^4.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
-				}
-			}
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -12589,9 +15399,9 @@
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+					"integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
 					"dev": true
 				},
 				"array-union": {
@@ -12640,9 +15450,9 @@
 					}
 				},
 				"fast-glob": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-					"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+					"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
@@ -12664,9 +15474,9 @@
 					}
 				},
 				"globby": {
-					"version": "11.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-					"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+					"integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
 					"dev": true,
 					"requires": {
 						"array-union": "^2.1.0",
@@ -12705,18 +15515,19 @@
 					}
 				},
 				"log-symbols": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-					"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+					"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^4.0.0"
+						"chalk": "^4.1.0",
+						"is-unicode-supported": "^0.1.0"
 					}
 				},
 				"map-obj": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-					"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+					"integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
 					"dev": true
 				},
 				"meow": {
@@ -12782,14 +15593,14 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -12910,18 +15721,6 @@
 				}
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"nth-check": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -13005,13 +15804,13 @@
 			"dev": true
 		},
 		"object-is": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-			"integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"object-keys": {
@@ -13065,13 +15864,100 @@
 			}
 		},
 		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+			"integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
+				"es-abstract": "^1.18.0-next.2"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"object.pick": {
@@ -13095,15 +15981,6 @@
 				"has": "^1.0.3"
 			}
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13120,9 +15997,9 @@
 			"dev": true
 		},
 		"opener": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-			"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
 			"dev": true
 		},
 		"optionator": {
@@ -13151,26 +16028,10 @@
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
-		},
 		"p-each-series": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-			"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+			"integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
 			"dev": true
 		},
 		"p-finally": {
@@ -13279,19 +16140,19 @@
 			"dev": true
 		},
 		"parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"dev": true
+		},
+		"parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"parse5": "^6.0.1"
 			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -13339,12 +16200,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
 		"path-type": {
@@ -13426,57 +16281,12 @@
 			}
 		},
 		"pkg-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
+				"find-up": "^2.1.0"
 			}
 		},
 		"plur": {
@@ -13494,12 +16304,6 @@
 			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
 			"dev": true
 		},
-		"pn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
-		},
 		"portfinder": {
 			"version": "1.0.28",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -13512,9 +16316,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -13573,13 +16377,13 @@
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz",
-			"integrity": "sha512-GVu+j7vwMTKUGhGXckYAFAAG5tTJUkSt8LuSyimtZdVVmdAEZYYqserkAgX8vwMhgGDPA4vJtWt7VgFxgiooDA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-10.0.0.tgz",
+			"integrity": "sha512-55BPj5FudpCiPZzBaO+MOeqmwMDa+nV9/0QBJBfhZjYg6D9hE+rW9lpMBLTJoF4OTXnS5Po4yM1nMlgkPbCxFg==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.17",
-				"postcss-values-parser": "^3.0.5"
+				"postcss-values-parser": "^4.0.0"
 			}
 		},
 		"postcss-html": {
@@ -13610,9 +16414,9 @@
 			}
 		},
 		"postcss-load-config": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-			"integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
+			"integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^5.0.0",
@@ -13631,6 +16435,12 @@
 				"schema-utils": "^1.0.0"
 			},
 			"dependencies": {
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -13649,6 +16459,17 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
 					}
 				}
 			}
@@ -13691,14 +16512,15 @@
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+					"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
 						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
+						"uniq": "^1.0.1",
+						"util-deprecate": "^1.0.2"
 					}
 				}
 			}
@@ -13714,14 +16536,15 @@
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+					"integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
 					"dev": true,
 					"requires": {
 						"cssesc": "^3.0.0",
 						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
+						"uniq": "^1.0.1",
+						"util-deprecate": "^1.0.2"
 					}
 				}
 			}
@@ -13839,15 +16662,14 @@
 			"dev": true
 		},
 		"postcss-values-parser": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.2.1.tgz",
-			"integrity": "sha512-SQ7/88VE9LhJh9gc27/hqnSU/aZaREVJcRVccXBmajgP2RkjdJzNyH/a9GCVMI5nsRhT0jC5HpUMwfkz81DVVg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
+			"integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.1.4",
-				"is-url-superb": "^3.0.0",
-				"postcss": "^7.0.5",
-				"url-regex": "^5.0.0"
+				"is-url-superb": "^4.0.0",
+				"postcss": "^7.0.5"
 			},
 			"dependencies": {
 				"color-name": {
@@ -13871,9 +16693,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -13886,24 +16708,23 @@
 			}
 		},
 		"pretty-format": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+			"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^25.5.0",
+				"@jest/types": "^26.6.2",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^4.0.0",
-				"react-is": "^16.12.0"
+				"react-is": "^17.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -13920,6 +16741,12 @@
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"react-is": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 					"dev": true
 				}
 			}
@@ -13949,13 +16776,13 @@
 			"dev": true
 		},
 		"prompts": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.1.tgz",
+			"integrity": "sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.4"
+				"sisteransi": "^1.0.5"
 			}
 		},
 		"prop-types": {
@@ -13978,16 +16805,6 @@
 				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
-			}
-		},
-		"proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-			"dev": true,
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
 			}
 		},
 		"proxy-from-env": {
@@ -14029,9 +16846,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
 			}
@@ -14075,18 +16892,18 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"puppeteer": {
-			"version": "npm:puppeteer-core@3.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+		"puppeteer-core": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
 			"dev": true,
 			"requires": {
-				"@types/mime-types": "^2.1.0",
 				"debug": "^4.1.0",
+				"devtools-protocol": "0.0.818844",
 				"extract-zip": "^2.0.0",
 				"https-proxy-agent": "^4.0.0",
-				"mime": "^2.0.3",
-				"mime-types": "^2.1.25",
+				"node-fetch": "^2.6.1",
+				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
 				"rimraf": "^3.0.2",
@@ -14095,6 +16912,64 @@
 				"ws": "^7.2.3"
 			},
 			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -14138,6 +17013,12 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
 		"quick-lru": {
@@ -14190,22 +17071,22 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"dev": true
-		},
 		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+			"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "1",
+				"string_decoder": "0.10"
+			},
+			"dependencies": {
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
 			}
 		},
 		"rc": {
@@ -14235,9 +17116,9 @@
 			}
 		},
 		"react": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
@@ -14246,9 +17127,9 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
@@ -14264,9 +17145,9 @@
 			"dev": true
 		},
 		"react-test-renderer": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
-			"integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+			"integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
@@ -14312,11 +17193,10 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-			"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
@@ -14343,12 +17223,6 @@
 				}
 			}
 		},
-		"realpath-native": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
-			"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
-			"dev": true
-		},
 		"redent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -14366,9 +17240,9 @@
 			"dev": true
 		},
 		"regenerate": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
-			"integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
@@ -14422,9 +17296,9 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-			"integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -14448,9 +17322,9 @@
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
+			"integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -14538,15 +17412,6 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
-		},
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -14590,6 +17455,12 @@
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -14629,6 +17500,12 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
 		},
 		"require-main-filename": {
@@ -14824,10 +17701,13 @@
 			}
 		},
 		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -14936,132 +17816,13 @@
 				}
 			}
 		},
-		"sass-graph": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
-			"integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+		"sass": {
+			"version": "1.32.8",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+			"integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^13.3.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-					"dev": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				},
-				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
+				"chokidar": ">=2.0.0 <4.0.0"
 			}
 		},
 		"sass-lint": {
@@ -15391,12 +18152,6 @@
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
 				"clone-deep": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -15428,17 +18183,6 @@
 						"json5": "^1.0.1"
 					}
 				},
-				"schema-utils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"ajv": "^6.12.2",
-						"ajv-keywords": "^3.4.1"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -15463,12 +18207,12 @@
 			"dev": true
 		},
 		"saxes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+			"integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
 			"dev": true,
 			"requires": {
-				"xmlchars": "^2.1.1"
+				"xmlchars": "^2.2.0"
 			}
 		},
 		"scheduler": {
@@ -15482,42 +18226,33 @@
 			}
 		},
 		"schema-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+			"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-errors": "^1.0.0",
-				"ajv-keywords": "^3.1.0"
+				"@types/json-schema": "^7.0.5",
+				"ajv": "^6.12.4",
+				"ajv-keywords": "^3.5.2"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"ajv-keywords": {
 					"version": "3.5.2",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
-				}
-			}
-		},
-		"scss-tokenizer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-			"dev": true,
-			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
 				}
 			}
 		},
@@ -15527,58 +18262,6 @@
 			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 			"dev": true
 		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
-			}
-		},
 		"serialize-javascript": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -15586,18 +18269,6 @@
 			"dev": true,
 			"requires": {
 				"randombytes": "^2.1.0"
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"dev": true,
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
 			}
 		},
 		"set-blocking": {
@@ -15633,12 +18304,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
 		},
 		"sha.js": {
@@ -15723,6 +18388,17 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
+		},
+		"sirv": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.11.tgz",
+			"integrity": "sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==",
+			"dev": true,
+			"requires": {
+				"@polka/url": "^1.0.0-next.9",
+				"mime": "^2.3.1",
+				"totalist": "^1.0.0"
+			}
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -16040,12 +18716,12 @@
 			}
 		},
 		"ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
 			"dev": true,
 			"requires": {
-				"figgy-pudding": "^3.5.1"
+				"minipass": "^3.1.1"
 			}
 		},
 		"stable": {
@@ -16055,10 +18731,21 @@
 			"dev": true
 		},
 		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
-			"dev": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"state-toggle": {
 			"version": "1.0.3",
@@ -16085,21 +18772,6 @@
 						"is-descriptor": "^0.1.0"
 					}
 				}
-			}
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true
-		},
-		"stdout-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
 			}
 		},
 		"stealthy-require": {
@@ -16154,30 +18826,13 @@
 			"dev": true
 		},
 		"string-length": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^5.2.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
 			}
 		},
 		"string-template": {
@@ -16229,14 +18884,100 @@
 			}
 		},
 		"string.prototype.trim": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-			"integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz",
+			"integrity": "sha512-hWCk/iqf7lp0/AgTF7/ddO1IWtSNPASjlzCicV5irAVdE1grjsneK26YG6xACMBEdCvO8fUST0UzDMh/2Qy+9Q==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.18.0-next.2"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.2",
+						"is-string": "^1.0.5",
+						"object-inspect": "^1.9.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"object-inspect": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"string.prototype.trimend": {
@@ -16478,17 +19219,6 @@
 				"stylelint-config-recommended": "^3.0.0"
 			}
 		},
-		"stylelint-config-wordpress": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
-			"integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
-			"dev": true,
-			"requires": {
-				"stylelint-config-recommended": "^3.0.0",
-				"stylelint-config-recommended-scss": "^4.2.0",
-				"stylelint-scss": "^3.17.2"
-			}
-		},
 		"stylelint-scss": {
 			"version": "3.18.0",
 			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
@@ -16534,9 +19264,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
-			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0",
@@ -16550,9 +19280,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -16631,35 +19361,52 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+			"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
 			"dev": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.12",
-				"inherits": "2"
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^3.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				}
 			}
 		},
 		"tar-fs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-			"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
 				"pump": "^3.0.0",
-				"tar-stream": "^2.0.0"
+				"tar-stream": "^2.1.4"
 			}
 		},
 		"tar-stream": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-			"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 			"dev": true,
 			"requires": {
-				"bl": "^4.0.1",
+				"bl": "^4.0.3",
 				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -16690,18 +19437,18 @@
 			},
 			"dependencies": {
 				"ansi-escapes": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+					"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
 					"dev": true,
 					"requires": {
-						"type-fest": "^0.11.0"
+						"type-fest": "^0.21.3"
 					}
 				},
 				"type-fest": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+					"version": "0.21.3",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+					"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 					"dev": true
 				}
 			}
@@ -16734,236 +19481,24 @@
 				"webpack-sources": "^1.4.3"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
-				"cacache": {
-					"version": "15.0.5",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
-					"integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
-					"dev": true,
-					"requires": {
-						"@npmcli/move-file": "^1.0.1",
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
-						"minipass-collect": "^1.0.2",
-						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
-						"p-map": "^4.0.0",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^3.0.2",
-						"ssri": "^8.0.0",
-						"tar": "^6.0.2",
-						"unique-filename": "^1.1.1"
-					}
-				},
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-					"dev": true
-				},
-				"find-cache-dir": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^3.0.2",
-						"pkg-dir": "^4.1.0"
-					}
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"jest-worker": {
-					"version": "26.3.0",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-					"integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
-					"dev": true,
-					"requires": {
-						"@types/node": "*",
-						"merge-stream": "^2.0.0",
-						"supports-color": "^7.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				},
 				"p-limit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-					"integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"yocto-queue": "^0.1.0"
 					}
 				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
-					},
-					"dependencies": {
-						"p-limit": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-							"dev": true,
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						}
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
 					}
-				},
-				"p-map": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-					"dev": true,
-					"requires": {
-						"aggregate-error": "^3.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"schema-utils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"ajv": "^6.12.2",
-						"ajv-keywords": "^3.4.1"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"ssri": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
-					"integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
-					"dev": true,
-					"requires": {
-						"minipass": "^3.1.1"
-					}
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"tar": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-					"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
-					"dev": true,
-					"requires": {
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"minipass": "^3.0.0",
-						"minizlib": "^2.1.1",
-						"mkdirp": "^1.0.3",
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
 				}
 			}
 		},
@@ -17040,9 +19575,9 @@
 			}
 		},
 		"timers-browserify": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
 			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
@@ -17063,21 +19598,15 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
 				}
 			}
-		},
-		"tlds": {
-			"version": "1.208.0",
-			"resolved": "https://registry.npmjs.org/tlds/-/tlds-1.208.0.tgz",
-			"integrity": "sha512-6kbY7GJpRQXwBddSOAbVUZXjObbCGFXliWWN+kOSEoRWIOyRWLB6zdeKC/Tguwwenl/KsUx016XR50EdHYsxZw==",
-			"dev": true
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -17139,38 +19668,30 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+		"totalist": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+			"integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-			"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+			"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
 			"dev": true,
 			"requires": {
-				"ip-regex": "^2.1.0",
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
-			},
-			"dependencies": {
-				"ip-regex": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-					"dev": true
-				}
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.1.2"
 			}
 		},
 		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+			"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "^2.1.1"
 			}
 		},
 		"tree-kill": {
@@ -17203,31 +19724,39 @@
 			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
 			"dev": true
 		},
-		"true-case-path": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+		"tsconfig-paths": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+			"integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.2"
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.1",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
-		"tryer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
-			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
-			"dev": true
-		},
 		"tslib": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tsutils": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -17281,16 +19810,6 @@
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"dev": true
 		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"dev": true,
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -17312,6 +19831,26 @@
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
 		},
+		"unbox-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has-bigints": "^1.0.1",
+				"has-symbols": "^1.0.2",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
+			}
+		},
 		"unbzip2-stream": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -17320,18 +19859,6 @@
 			"requires": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
 			}
 		},
 		"unherit": {
@@ -17481,12 +20008,6 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
-		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -17584,12 +20105,6 @@
 				"schema-utils": "^2.5.0"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -17609,28 +20124,7 @@
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
 					}
-				},
-				"schema-utils": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-					"integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.4",
-						"ajv": "^6.12.2",
-						"ajv-keywords": "^3.4.1"
-					}
 				}
-			}
-		},
-		"url-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
-			"integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
-			"dev": true,
-			"requires": {
-				"ip-regex": "^4.1.0",
-				"tlds": "^1.203.0"
 			}
 		},
 		"use": {
@@ -17683,17 +20177,12 @@
 				"object.getownpropertydescriptors": "^2.1.0"
 			}
 		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-			"dev": true
-		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"optional": true
 		},
 		"v8-compile-cache": {
 			"version": "2.1.1",
@@ -17702,9 +20191,9 @@
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
-			"integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.1.tgz",
+			"integrity": "sha512-p0BB09E5FRjx0ELN6RgusIPsSPhtgexSRcKETybEs6IGOTXJSZqfwxp7r//55nnu0f1AxltY5VvdVqy2vZf9AA==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
@@ -17729,12 +20218,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -17814,13 +20297,11 @@
 			}
 		},
 		"w3c-xmlserializer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+			"integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
 			"dev": true,
 			"requires": {
-				"domexception": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
 				"xml-name-validator": "^3.0.0"
 			}
 		},
@@ -17838,9 +20319,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.11",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
 					"dev": true
 				}
 			}
@@ -17885,21 +20366,21 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-			"integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
 				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.0"
+				"watchpack-chokidar2": "^2.0.1"
 			}
 		},
 		"watchpack-chokidar2": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-			"integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+			"integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -18038,15 +20519,15 @@
 			}
 		},
 		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+			"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
 			"dev": true
 		},
 		"webpack": {
-			"version": "4.44.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-			"integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+			"integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.9.0",
@@ -18057,7 +20538,7 @@
 				"ajv": "^6.10.2",
 				"ajv-keywords": "^3.4.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^4.3.0",
+				"enhanced-resolve": "^4.5.0",
 				"eslint-scope": "^4.0.3",
 				"json-parse-better-errors": "^1.0.2",
 				"loader-runner": "^2.4.0",
@@ -18075,9 +20556,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 					"dev": true
 				},
 				"ajv-keywords": {
@@ -18085,6 +20566,29 @@
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
 					"dev": true
+				},
+				"cacache": {
+					"version": "12.0.4",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+					"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"infer-owner": "^1.0.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
+					}
 				},
 				"eslint-scope": {
 					"version": "4.0.3",
@@ -18095,6 +20599,32 @@
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
+				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+					"dev": true
 				},
 				"json5": {
 					"version": "1.0.1",
@@ -18114,6 +20644,35 @@
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
 						"json5": "^1.0.1"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
 					}
 				},
 				"micromatch": {
@@ -18137,6 +20696,65 @@
 						"to-regex": "^3.0.2"
 					}
 				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1"
+					}
+				},
 				"terser-webpack-plugin": {
 					"version": "1.4.5",
 					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -18153,55 +20771,65 @@
 						"webpack-sources": "^1.4.0",
 						"worker-farm": "^1.7.0"
 					}
+				},
+				"webpack-sources": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
 				}
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.8.0.tgz",
-			"integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.0.tgz",
+			"integrity": "sha512-9DhNa+aXpqdHk8LkLPTBU/dMfl84Y+WE2+KnfI6rSpNRNVKa0VGLjPd2pjFubDeqnWmulFggxmWBxhfJXZnR0g==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-walk": "^7.1.1",
-				"bfj": "^6.1.1",
-				"chalk": "^2.4.1",
-				"commander": "^2.18.0",
-				"ejs": "^2.6.1",
-				"express": "^4.16.3",
-				"filesize": "^3.6.1",
-				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.15",
-				"mkdirp": "^0.5.1",
-				"opener": "^1.5.1",
-				"ws": "^6.0.0"
+				"acorn": "^8.0.4",
+				"acorn-walk": "^8.0.0",
+				"chalk": "^4.1.0",
+				"commander": "^6.2.0",
+				"gzip-size": "^6.0.0",
+				"lodash": "^4.17.20",
+				"opener": "^1.5.2",
+				"sirv": "^1.0.7",
+				"ws": "^7.3.1"
 			},
 			"dependencies": {
-				"acorn-walk": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+				"acorn": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+					"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
 					"dev": true
 				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
+				"acorn-walk": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
+					"integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==",
+					"dev": true
 				},
-				"ws": {
+				"commander": {
 					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-					"dev": true,
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+					"dev": true
 				}
 			}
 		},
@@ -18361,6 +20989,15 @@
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
 				"resolve-cwd": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -18477,13 +21114,13 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+			"integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "^2.0.1",
+				"source-map": "^0.6.1"
 			}
 		},
 		"websocket-driver": {
@@ -18519,14 +21156,14 @@
 			"dev": true
 		},
 		"whatwg-url": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
+			"integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash": "^4.7.0",
+				"tr46": "^2.0.2",
+				"webidl-conversions": "^6.1.0"
 			}
 		},
 		"which": {
@@ -18538,47 +21175,24 @@
 				"isexe": "^2.0.0"
 			}
 		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -18607,12 +21221,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -18644,9 +21257,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -18684,9 +21297,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+			"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
 			"dev": true
 		},
 		"x-is-string": {
@@ -18714,21 +21327,21 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.2.tgz",
+			"integrity": "sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w==",
 			"dev": true
 		},
 		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true
 		},
 		"yargs": {
@@ -18818,9 +21431,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -18858,6 +21471,18 @@
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
+		},
+		"zwitch": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+			"integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"devDependencies": {
 		"@webdevstudios/css-coding-standards": "^1.0.1",
 		"@webdevstudios/js-coding-standards": "^1.1.1",
-		"@wordpress/scripts": "^12.1.1",
+		"@wordpress/scripts": "^14.1.0",
 		"ignore-emit-webpack-plugin": "^2.0.2"
 	},
 	"eslintConfig": {


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/wds-block-starter/issues/40

Large bump from WP Scripts `12.1.1` to `14.1.0`.

Note: I added details to the README changelog, and recommend that this be considered a minor change.

### Screenshot
Editor view displaying block in editor
<img width="1111" alt="Screen Shot 2021-04-07 at 2 06 34 PM" src="https://user-images.githubusercontent.com/25035900/113913979-f70d2380-97aa-11eb-86b0-2f43dd8f3f8a.png">

Frontend view displaying block on the frontend
<img width="1099" alt="Screen Shot 2021-04-07 at 2 06 23 PM" src="https://user-images.githubusercontent.com/25035900/113913977-f70d2380-97aa-11eb-8942-bdd682e75b12.png">

### Steps to verify the solution
1. Run `npm install` 
2. Verify `@wordpress/scripts` is visible in the package-lock.json
3. Run `npm run build` and verify the plugin built correctly by inserting the demo block

### Other
- [NA] Is this issue accessible? (Section 508/WCAG 2.1AA)
- [NA] Does this pass CrossBrowserTesting.com? (Edge, Safari, Chrome, Firefox)
- [NA] Will this pull request require [updating the wiki?](https://github.com/WebDevStudios/wds-block-starter/wiki)
